### PR TITLE
Add file browse endpoints

### DIFF
--- a/api/files/models.py
+++ b/api/files/models.py
@@ -177,3 +177,30 @@ class PaginatedFileResponse(SQLModel):
     has_prev: bool
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class FileBrowserColumns(SQLModel):
+    """Individual file/folder item for file browser"""
+    name: str
+    date: str
+    size: int | None = None  # None for directories
+    dir: bool  # True for directories, False for files
+
+
+class FileBrowserFolder(SQLModel):
+    """Folder item for file browser"""
+    name: str
+    date: str
+
+
+class FileBrowserFile(SQLModel):
+    """File item for file browser"""
+    name: str
+    date: str
+    size: int
+
+
+class FileBrowserData(SQLModel):
+    """File browser data structure with separate folders and files"""
+    folders: list[FileBrowserFolder]
+    files: list[FileBrowserFile]

--- a/api/files/models.py
+++ b/api/files/models.py
@@ -12,6 +12,7 @@ from pydantic import ConfigDict
 
 class FileType(str, Enum):
     """File type categories"""
+
     FASTQ = "fastq"
     BAM = "bam"
     VCF = "vcf"
@@ -26,12 +27,14 @@ class FileType(str, Enum):
 
 class EntityType(str, Enum):
     """Entity types that can have files"""
+
     PROJECT = "project"
     RUN = "run"
 
 
 class StorageBackend(str, Enum):
     """Storage backend types"""
+
     LOCAL = "local"
     S3 = "s3"
     AZURE = "azure"
@@ -73,12 +76,14 @@ class File(SQLModel, table=True):
         """Generate a unique file ID"""
         import secrets
         import string
+
         alphabet = string.ascii_letters + string.digits
-        return ''.join(secrets.choice(alphabet) for _ in range(12))
+        return "".join(secrets.choice(alphabet) for _ in range(12))
 
 
 class FileCreate(SQLModel):
     """Request model for creating a file"""
+
     filename: str
     original_filename: str | None = None
     description: str | None = None
@@ -93,6 +98,7 @@ class FileCreate(SQLModel):
 
 class FileUpdate(SQLModel):
     """Request model for updating file metadata"""
+
     filename: str | None = None
     description: str | None = None
     file_type: FileType | None = None
@@ -104,6 +110,7 @@ class FileUpdate(SQLModel):
 
 class FilePublic(SQLModel):
     """Public file representation"""
+
     file_id: str
     filename: str
     original_filename: str
@@ -123,6 +130,7 @@ class FilePublic(SQLModel):
 
 class FilesPublic(SQLModel):
     """Paginated file listing"""
+
     data: List[FilePublic]
     total_items: int
     total_pages: int
@@ -134,6 +142,7 @@ class FilesPublic(SQLModel):
 
 class FileUploadRequest(SQLModel):
     """Request model for file upload"""
+
     filename: str
     description: str | None = None
     file_type: FileType = FileType.OTHER
@@ -144,6 +153,7 @@ class FileUploadRequest(SQLModel):
 
 class FileUploadResponse(SQLModel):
     """Response model for file upload"""
+
     file_id: str
     filename: str
     file_size: int | None = None
@@ -154,6 +164,7 @@ class FileUploadResponse(SQLModel):
 
 class FileFilters(SQLModel):
     """File filtering options"""
+
     entity_type: EntityType | None = None
     entity_id: str | None = None
     file_type: FileType | None = None
@@ -168,6 +179,7 @@ class FileFilters(SQLModel):
 
 class PaginatedFileResponse(SQLModel):
     """Paginated response for file listings"""
+
     data: list[FilePublic]
     total_items: int
     total_pages: int
@@ -181,6 +193,7 @@ class PaginatedFileResponse(SQLModel):
 
 class FileBrowserColumns(SQLModel):
     """Individual file/folder item for file browser"""
+
     name: str
     date: str
     size: int | None = None  # None for directories
@@ -189,12 +202,14 @@ class FileBrowserColumns(SQLModel):
 
 class FileBrowserFolder(SQLModel):
     """Folder item for file browser"""
+
     name: str
     date: str
 
 
 class FileBrowserFile(SQLModel):
     """File item for file browser"""
+
     name: str
     date: str
     size: int
@@ -202,5 +217,6 @@ class FileBrowserFile(SQLModel):
 
 class FileBrowserData(SQLModel):
     """File browser data structure with separate folders and files"""
+
     folders: list[FileBrowserFolder]
     files: list[FileBrowserFile]

--- a/api/files/models.py
+++ b/api/files/models.py
@@ -191,15 +191,6 @@ class PaginatedFileResponse(SQLModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class FileBrowserColumns(SQLModel):
-    """Individual file/folder item for file browser"""
-
-    name: str
-    date: str
-    size: int | None = None  # None for directories
-    dir: bool  # True for directories, False for files
-
-
 class FileBrowserFolder(SQLModel):
     """Folder item for file browser"""
 

--- a/api/files/routes.py
+++ b/api/files/routes.py
@@ -123,16 +123,31 @@ def list_files(
     "/browse", response_model=FileBrowserData, summary="Browse filesystem directory"
 )
 def browse_filesystem(
-    directory_path: str = Query("", description="Directory path to browse"),
-    storage_root: str = Query("storage", description="Storage root directory"),
+    directory_path: str = Query(
+        "", description="Directory path to browse (local path or s3://bucket/key)"
+    ),
+    storage_root: str = Query(
+        "storage", description="Storage root directory (ignored for S3 paths)"
+    ),
 ) -> FileBrowserData:
     """
-    Browse a filesystem directory and return folders and files in structured format.
+    Browse a filesystem directory or S3 bucket and return folders and files in structured format.
 
-    - **directory_path**: Path relative to storage root (empty for root)
-    - **storage_root**: Base storage directory (defaults to 'storage')
+    Supports both local filesystem and AWS S3:
+    - **Local paths**: Relative to storage_root (empty for root) or absolute paths
+    - **S3 paths**: Use s3://bucket/key format (e.g., s3://my-bucket/path/to/folder/)
+    - **storage_root**: Base storage directory for local paths (ignored for S3)
 
     Returns separate arrays for folders and files with name, date, and size information.
+    
+    For S3 paths:
+    - Requires AWS credentials to be configured
+    - Folders represent S3 prefixes (common prefixes)
+    - Files show S3 object metadata (size, last modified)
+    
+    Examples:
+    - Local: `/browse?directory_path=project1/data`
+    - S3: `/browse?directory_path=s3://my-bucket/project1/data/`
     """
     return services.browse_filesystem(directory_path, storage_root)
 

--- a/api/files/routes.py
+++ b/api/files/routes.py
@@ -202,11 +202,11 @@ def get_file(session: SessionDep, file_id: str) -> FilePublic:
     """
     try:
         return services.get_file(session, file_id)
-    except Exception:
+    except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"File with id {file_id} not found",
-        )
+        ) from exc
 
 
 @router.put("/{file_id}", response_model=FilePublic, summary="Update file metadata")
@@ -221,11 +221,11 @@ def update_file(
     """
     try:
         return services.update_file(session, file_id, file_update)
-    except Exception:
+    except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"File with id {file_id} not found",
-        )
+        ) from exc
 
 
 @router.delete(
@@ -244,11 +244,11 @@ def delete_file(session: SessionDep, file_id: str) -> None:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"File with id {file_id} not found",
             )
-    except Exception:
+    except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"File with id {file_id} not found",
-        )
+        ) from exc
 
 
 @router.get("/{file_id}/content", summary="Download file content")
@@ -276,11 +276,11 @@ def download_file(session: SessionDep, file_id: str):
                 "Content-Disposition": f"attachment; filename={file_record.filename}"
             },
         )
-    except Exception:
+    except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"File with id {file_id} not found or content not available",
-        )
+        ) from exc
 
 
 @router.post(
@@ -298,11 +298,11 @@ def upload_file_content(
     try:
         file_content = content.file.read()
         return services.update_file_content(session, file_id, file_content)
-    except Exception:
+    except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"File with id {file_id} not found",
-        )
+        ) from exc
 
 
 @router.get(

--- a/api/files/routes.py
+++ b/api/files/routes.py
@@ -139,12 +139,12 @@ def browse_filesystem(
     - **storage_root**: Base storage directory for local paths (ignored for S3)
 
     Returns separate arrays for folders and files with name, date, and size information.
-    
+
     For S3 paths:
     - Requires AWS credentials to be configured
     - Folders represent S3 prefixes (common prefixes)
     - Files show S3 object metadata (size, last modified)
-    
+
     Examples:
     - Local: `/browse?directory_path=project1/data`
     - S3: `/browse?directory_path=s3://my-bucket/project1/data/`

--- a/api/files/routes.py
+++ b/api/files/routes.py
@@ -3,7 +3,15 @@ Routes/endpoints for the Files API
 """
 
 from typing import Optional
-from fastapi import APIRouter, Query, HTTPException, status, UploadFile, File as FastAPIFile, Form
+from fastapi import (
+    APIRouter,
+    Query,
+    HTTPException,
+    status,
+    UploadFile,
+    File as FastAPIFile,
+    Form,
+)
 from fastapi.responses import StreamingResponse
 from core.deps import SessionDep
 from api.files.models import (
@@ -25,7 +33,7 @@ router = APIRouter(prefix="/files", tags=["Files"])
     "",
     response_model=FilePublic,
     status_code=status.HTTP_201_CREATED,
-    summary="Create a new file record"
+    summary="Create a new file record",
 )
 def create_file(
     session: SessionDep,
@@ -36,7 +44,7 @@ def create_file(
     file_type: FileType = Form(FileType.OTHER),
     is_public: bool = Form(False),
     created_by: Optional[str] = Form(None),
-    content: Optional[UploadFile] = FastAPIFile(None)
+    content: Optional[UploadFile] = FastAPIFile(None),
 ) -> FilePublic:
     """
     Create a new file record with optional file content upload.
@@ -57,7 +65,7 @@ def create_file(
         entity_type=entity_type,
         entity_id=entity_id,
         is_public=is_public,
-        created_by=created_by
+        created_by=created_by,
     )
 
     file_content = None
@@ -70,17 +78,23 @@ def create_file(
 @router.get(
     "",
     response_model=PaginatedFileResponse,
-    summary="List files with filtering and pagination"
+    summary="List files with filtering and pagination",
 )
 def list_files(
     session: SessionDep,
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     per_page: int = Query(20, ge=1, le=100, description="Number of items per page"),
-    entity_type: Optional[EntityType] = Query(None, description="Filter by entity type"),
+    entity_type: Optional[EntityType] = Query(
+        None, description="Filter by entity type"
+    ),
     entity_id: Optional[str] = Query(None, description="Filter by entity ID"),
     file_type: Optional[FileType] = Query(None, description="Filter by file type"),
-    search: Optional[str] = Query(None, description="Search in filename and description"),
-    is_public: Optional[bool] = Query(None, description="Filter by public/private status"),
+    search: Optional[str] = Query(
+        None, description="Search in filename and description"
+    ),
+    is_public: Optional[bool] = Query(
+        None, description="Filter by public/private status"
+    ),
     created_by: Optional[str] = Query(None, description="Filter by creator"),
 ) -> PaginatedFileResponse:
     """
@@ -106,20 +120,18 @@ def list_files(
 
 
 @router.get(
-    "/browse",
-    response_model=FileBrowserData,
-    summary="Browse filesystem directory"
+    "/browse", response_model=FileBrowserData, summary="Browse filesystem directory"
 )
 def browse_filesystem(
     directory_path: str = Query("", description="Directory path to browse"),
-    storage_root: str = Query("storage", description="Storage root directory")
+    storage_root: str = Query("storage", description="Storage root directory"),
 ) -> FileBrowserData:
     """
     Browse a filesystem directory and return folders and files in structured format.
-    
+
     - **directory_path**: Path relative to storage root (empty for root)
     - **storage_root**: Base storage directory (defaults to 'storage')
-    
+
     Returns separate arrays for folders and files with name, date, and size information.
     """
     return services.browse_filesystem(directory_path, storage_root)
@@ -128,22 +140,28 @@ def browse_filesystem(
 @router.get(
     "/browse-db",
     response_model=FileBrowserData,
-    summary="List database files in browser format"
+    summary="List database files in browser format",
 )
 def list_files_browser_format(
     session: SessionDep,
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     per_page: int = Query(20, ge=1, le=100, description="Number of items per page"),
-    entity_type: Optional[EntityType] = Query(None, description="Filter by entity type"),
+    entity_type: Optional[EntityType] = Query(
+        None, description="Filter by entity type"
+    ),
     entity_id: Optional[str] = Query(None, description="Filter by entity ID"),
     file_type: Optional[FileType] = Query(None, description="Filter by file type"),
-    search: Optional[str] = Query(None, description="Search in filename and description"),
-    is_public: Optional[bool] = Query(None, description="Filter by public/private status"),
+    search: Optional[str] = Query(
+        None, description="Search in filename and description"
+    ),
+    is_public: Optional[bool] = Query(
+        None, description="Filter by public/private status"
+    ),
     created_by: Optional[str] = Query(None, description="Filter by creator"),
 ) -> FileBrowserData:
     """
     Get database files in FileBrowserData format (files only, no folders).
-    
+
     This endpoint returns the same file data as the regular list_files endpoint,
     but formatted to match the FileBrowserData structure with separate folders and files arrays.
     Since database files don't have folder structure, the folders array will be empty.
@@ -160,15 +178,8 @@ def list_files_browser_format(
     return services.list_files_as_browser_data(session, filters, page, per_page)
 
 
-@router.get(
-    "/{file_id}",
-    response_model=FilePublic,
-    summary="Get file by ID"
-)
-def get_file(
-    session: SessionDep,
-    file_id: str
-) -> FilePublic:
+@router.get("/{file_id}", response_model=FilePublic, summary="Get file by ID")
+def get_file(session: SessionDep, file_id: str) -> FilePublic:
     """
     Get a single file by its file_id.
 
@@ -179,19 +190,13 @@ def get_file(
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"File with id {file_id} not found"
+            detail=f"File with id {file_id} not found",
         )
 
 
-@router.put(
-    "/{file_id}",
-    response_model=FilePublic,
-    summary="Update file metadata"
-)
+@router.put("/{file_id}", response_model=FilePublic, summary="Update file metadata")
 def update_file(
-    session: SessionDep,
-    file_id: str,
-    file_update: FileUpdate
+    session: SessionDep, file_id: str, file_update: FileUpdate
 ) -> FilePublic:
     """
     Update file metadata.
@@ -204,19 +209,14 @@ def update_file(
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"File with id {file_id} not found"
+            detail=f"File with id {file_id} not found",
         )
 
 
 @router.delete(
-    "/{file_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    summary="Delete file"
+    "/{file_id}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete file"
 )
-def delete_file(
-    session: SessionDep,
-    file_id: str
-) -> None:
+def delete_file(session: SessionDep, file_id: str) -> None:
     """
     Delete a file and its content.
 
@@ -227,23 +227,17 @@ def delete_file(
         if not success:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"File with id {file_id} not found"
+                detail=f"File with id {file_id} not found",
             )
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"File with id {file_id} not found"
+            detail=f"File with id {file_id} not found",
         )
 
 
-@router.get(
-    "/{file_id}/content",
-    summary="Download file content"
-)
-def download_file(
-    session: SessionDep,
-    file_id: str
-):
+@router.get("/{file_id}/content", summary="Download file content")
+def download_file(session: SessionDep, file_id: str):
     """
     Download the content of a file.
 
@@ -265,24 +259,20 @@ def download_file(
             media_type=file_record.mime_type or "application/octet-stream",
             headers={
                 "Content-Disposition": f"attachment; filename={file_record.filename}"
-            }
+            },
         )
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"File with id {file_id} not found or content not available"
+            detail=f"File with id {file_id} not found or content not available",
         )
 
 
 @router.post(
-    "/{file_id}/content",
-    response_model=FilePublic,
-    summary="Upload file content"
+    "/{file_id}/content", response_model=FilePublic, summary="Upload file content"
 )
 def upload_file_content(
-    session: SessionDep,
-    file_id: str,
-    content: UploadFile = FastAPIFile(...)
+    session: SessionDep, file_id: str, content: UploadFile = FastAPIFile(...)
 ) -> FilePublic:
     """
     Upload content for an existing file record.
@@ -296,14 +286,14 @@ def upload_file_content(
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"File with id {file_id} not found"
+            detail=f"File with id {file_id} not found",
         )
 
 
 @router.get(
     "/entity/{entity_type}/{entity_id}",
     response_model=PaginatedFileResponse,
-    summary="List files for a specific entity."
+    summary="List files for a specific entity.",
 )
 def list_files_for_entity(
     session: SessionDep,
@@ -320,17 +310,16 @@ def list_files_for_entity(
     - **entity_type**: Either "project" or "run"
     - **entity_id**: The project ID or run barcode
     """
-    return services.list_files_for_entity(session, entity_type, entity_id, page, per_page, file_type)
+    return services.list_files_for_entity(
+        session, entity_type, entity_id, page, per_page, file_type
+    )
 
 
 @router.get(
-    "/entity/{entity_type}/{entity_id}/count",
-    summary="Get file count for entity"
+    "/entity/{entity_type}/{entity_id}/count", summary="Get file count for entity"
 )
 def get_file_count_for_entity(
-    session: SessionDep,
-    entity_type: EntityType,
-    entity_id: str
+    session: SessionDep, entity_type: EntityType, entity_id: str
 ) -> dict:
     """
     Get the total number of files for a specific project or run.
@@ -340,5 +329,3 @@ def get_file_count_for_entity(
     """
     count = services.get_file_count_for_entity(session, entity_type, entity_id)
     return {"entity_type": entity_type, "entity_id": entity_id, "file_count": count}
-
-

--- a/api/files/services.py
+++ b/api/files/services.py
@@ -15,6 +15,7 @@ from fastapi import HTTPException, status
 try:
     import boto3
     from botocore.exceptions import ClientError, NoCredentialsError
+
     BOTO3_AVAILABLE = True
 except ImportError:
     BOTO3_AVAILABLE = False
@@ -363,14 +364,14 @@ def browse_filesystem(
 ) -> FileBrowserData:
     """
     Browse filesystem directory and return structured data.
-    
+
     Automatically detects if the path is S3 (s3://bucket/key) or local filesystem
     and routes to the appropriate handler.
     """
     # Check if this is an S3 path
     if _is_s3_path(directory_path):
         return browse_s3(directory_path)
-    
+
     # Handle local filesystem
     return _browse_local_filesystem(directory_path, storage_root)
 
@@ -439,25 +440,25 @@ def _parse_s3_path(s3_path: str) -> tuple[str, str]:
     """Parse S3 path into bucket and prefix"""
     if not s3_path.startswith("s3://"):
         raise ValueError("Invalid S3 path format. Must start with s3://")
-    
+
     # Remove s3:// prefix
     path_without_scheme = s3_path[5:]
-    
+
     # Check for empty path after s3://
     if not path_without_scheme:
         raise ValueError("Invalid S3 path format. Bucket name is required")
-    
+
     # Split into bucket and key
     if "/" in path_without_scheme:
         bucket, key = path_without_scheme.split("/", 1)
     else:
         bucket = path_without_scheme
         key = ""
-    
+
     # Validate bucket name is not empty
     if not bucket:
         raise ValueError("Invalid S3 path format. Bucket name cannot be empty")
-    
+
     return bucket, key
 
 
@@ -468,7 +469,7 @@ def browse_s3(s3_path: str) -> FileBrowserData:
             status_code=status.HTTP_501_NOT_IMPLEMENTED,
             detail="S3 support not available. Install boto3 to enable S3 browsing.",
         )
-    
+
     try:
         bucket, prefix = _parse_s3_path(s3_path)
     except ValueError as e:
@@ -476,78 +477,76 @@ def browse_s3(s3_path: str) -> FileBrowserData:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
-    
+
     try:
         # Initialize S3 client
-        s3_client = boto3.client('s3')
-         
+        s3_client = boto3.client("s3")
+
         # List objects with the given prefix
-        paginator = s3_client.get_paginator('list_objects_v2')
+        paginator = s3_client.get_paginator("list_objects_v2")
         page_iterator = paginator.paginate(
-            Bucket=bucket,
-            Prefix=prefix,
-            Delimiter='/'  # This helps us get "folders"
+            Bucket=bucket, Prefix=prefix, Delimiter="/"  # This helps us get "folders"
         )
-        
+
         folders = []
         files = []
-        
+
         for page in page_iterator:
             # Handle "folders" (common prefixes)
-            for common_prefix in page.get('CommonPrefixes', []):
-                folder_prefix = common_prefix['Prefix']
+            for common_prefix in page.get("CommonPrefixes", []):
+                folder_prefix = common_prefix["Prefix"]
                 # Remove the current prefix to get just the folder name
-                folder_name = folder_prefix[len(prefix):].rstrip('/')
+                folder_name = folder_prefix[len(prefix) :].rstrip("/")
                 if folder_name:  # Skip empty names
-                    folders.append(FileBrowserFolder(
-                        name=folder_name,
-                        date=""  # S3 prefixes don't have modification dates
-                    ))
-            
+                    folders.append(
+                        FileBrowserFolder(
+                            name=folder_name,
+                            date="",  # S3 prefixes don't have modification dates
+                        )
+                    )
+
             # Handle actual files
-            for obj in page.get('Contents', []):
-                key = obj['Key']
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
                 # Skip if this is just the prefix itself (directory marker)
                 if key == prefix:
                     continue
-                
+
                 # Remove the current prefix to get just the file name
-                file_name = key[len(prefix):]
-                
+                file_name = key[len(prefix) :]
+
                 # Skip files that are in subdirectories (contain '/')
-                if '/' in file_name:
+                if "/" in file_name:
                     continue
-                
+
                 if file_name:  # Skip empty names
                     # Format the date
-                    mod_time = obj['LastModified']
+                    mod_time = obj["LastModified"]
                     date_str = mod_time.strftime("%Y-%m-%d %H:%M:%S")
-                    
-                    files.append(FileBrowserFile(
-                        name=file_name,
-                        date=date_str,
-                        size=obj['Size']
-                    ))
-        
+
+                    files.append(
+                        FileBrowserFile(name=file_name, date=date_str, size=obj["Size"])
+                    )
+
         # Sort folders and files by name
         folders.sort(key=lambda x: x.name.lower())
         files.sort(key=lambda x: x.name.lower())
-        
+
         return FileBrowserData(folders=folders, files=files)
-        
+
     except NoCredentialsError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="AWS credentials not found. Please configure AWS credentials.",
         )
     except ClientError as e:
-        error_code = e.response['Error']['Code']
-        if error_code == 'NoSuchBucket':
+        error_code = e.response["Error"]["Code"]
+        if error_code == "NoSuchBucket":
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"S3 bucket not found: {bucket}",
             )
-        elif error_code == 'AccessDenied':
+        elif error_code == "AccessDenied":
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Access denied to S3 bucket: {bucket}",

--- a/api/files/services.py
+++ b/api/files/services.py
@@ -33,7 +33,6 @@ from api.files.models import (
     FileBrowserData,
     FileBrowserFolder,
     FileBrowserFile,
-    FileBrowserColumns,
 )
 
 
@@ -476,7 +475,7 @@ def browse_s3(s3_path: str) -> FileBrowserData:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
-        )
+        ) from e
 
     try:
         # Initialize S3 client
@@ -496,7 +495,7 @@ def browse_s3(s3_path: str) -> FileBrowserData:
             for common_prefix in page.get("CommonPrefixes", []):
                 folder_prefix = common_prefix["Prefix"]
                 # Remove the current prefix to get just the folder name
-                folder_name = folder_prefix[len(prefix) :].rstrip("/")
+                folder_name = folder_prefix[len(prefix):].rstrip("/")
                 if folder_name:  # Skip empty names
                     folders.append(
                         FileBrowserFolder(
@@ -513,7 +512,7 @@ def browse_s3(s3_path: str) -> FileBrowserData:
                     continue
 
                 # Remove the current prefix to get just the file name
-                file_name = key[len(prefix) :]
+                file_name = key[len(prefix):]
 
                 # Skip files that are in subdirectories (contain '/')
                 if "/" in file_name:

--- a/api/runs/routes.py
+++ b/api/runs/routes.py
@@ -14,7 +14,7 @@ GET    /api/v0/runs/[id]/metrics       Retrieve demux metrics from Stat.json
 """
 
 from typing import Literal
-from fastapi import APIRouter, Query, status, HTTPException
+from fastapi import APIRouter, Query, status
 from core.deps import SessionDep, OpenSearchDep
 from api.runs.models import (
     IlluminaMetricsResponseModel,

--- a/tests/api/test_files.py
+++ b/tests/api/test_files.py
@@ -77,7 +77,7 @@ class TestFileModels:
             entity_type=EntityType.PROJECT,
             entity_id="PROJ001",
             is_public=True,
-            created_by="testuser"
+            created_by="testuser",
         )
 
         assert file_create.filename == "test.txt"
@@ -91,9 +91,7 @@ class TestFileModels:
     def test_file_update_model(self):
         """Test FileUpdate model validation"""
         file_update = FileUpdate(
-            filename="updated.txt",
-            description="Updated description",
-            is_public=False
+            filename="updated.txt", description="Updated description", is_public=False
         )
 
         assert file_update.filename == "updated.txt"
@@ -124,10 +122,7 @@ class TestFileServices:
     def test_generate_file_path(self):
         """Test file path generation"""
         path = generate_file_path(
-            EntityType.PROJECT,
-            "PROJ001",
-            FileType.FASTQ,
-            "sample.fastq"
+            EntityType.PROJECT, "PROJ001", FileType.FASTQ, "sample.fastq"
         )
 
         # Should contain entity type, entity id, file type, year, month, filename
@@ -150,14 +145,19 @@ class TestFileServices:
 
         # Should be SHA-256 hash
         assert len(checksum) == 64
-        assert checksum == "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f"
+        assert (
+            checksum
+            == "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f"
+        )
 
     def test_get_mime_type(self):
         """Test MIME type detection"""
         assert get_mime_type("test.txt") == "text/plain"
         assert get_mime_type("test.pdf") == "application/pdf"
         assert get_mime_type("test.jpg") == "image/jpeg"
-        assert get_mime_type("test.fastq") == "application/octet-stream"  # Unknown extension
+        assert (
+            get_mime_type("test.fastq") == "application/octet-stream"
+        )  # Unknown extension
 
     def test_create_file_without_content(self, session: Session, temp_storage):
         """Test creating file record without content"""
@@ -167,7 +167,7 @@ class TestFileServices:
             file_type=FileType.DOCUMENT,
             entity_type=EntityType.PROJECT,
             entity_id="PROJ001",
-            created_by="testuser"
+            created_by="testuser",
         )
 
         file_record = create_file(session, file_create, storage_root=temp_storage)
@@ -191,10 +191,12 @@ class TestFileServices:
             description="Test file",
             file_type=FileType.DOCUMENT,
             entity_type=EntityType.PROJECT,
-            entity_id="PROJ001"
+            entity_id="PROJ001",
         )
 
-        file_record = create_file(session, file_create, content, storage_root=temp_storage)
+        file_record = create_file(
+            session, file_create, content, storage_root=temp_storage
+        )
 
         assert file_record.file_size == len(content)
         assert file_record.checksum == calculate_file_checksum(content)
@@ -207,9 +209,7 @@ class TestFileServices:
     def test_get_file(self, session: Session, temp_storage):
         """Test getting file by file_id"""
         file_create = FileCreate(
-            filename="test.txt",
-            entity_type=EntityType.PROJECT,
-            entity_id="PROJ001"
+            filename="test.txt", entity_type=EntityType.PROJECT, entity_id="PROJ001"
         )
 
         created_file = create_file(session, file_create, storage_root=temp_storage)
@@ -232,15 +232,13 @@ class TestFileServices:
             filename="test.txt",
             description="Original description",
             entity_type=EntityType.PROJECT,
-            entity_id="PROJ001"
+            entity_id="PROJ001",
         )
 
         created_file = create_file(session, file_create, storage_root=temp_storage)
 
         file_update = FileUpdate(
-            filename="updated.txt",
-            description="Updated description",
-            is_public=True
+            filename="updated.txt", description="Updated description", is_public=True
         )
 
         updated_file = update_file(session, created_file.file_id, file_update)
@@ -253,12 +251,12 @@ class TestFileServices:
         """Test deleting file and content"""
         content = b"Hello, World!"
         file_create = FileCreate(
-            filename="test.txt",
-            entity_type=EntityType.PROJECT,
-            entity_id="PROJ001"
+            filename="test.txt", entity_type=EntityType.PROJECT, entity_id="PROJ001"
         )
 
-        created_file = create_file(session, file_create, content, storage_root=temp_storage)
+        created_file = create_file(
+            session, file_create, content, storage_root=temp_storage
+        )
         file_path = Path(temp_storage) / created_file.file_path
 
         # Verify file exists
@@ -296,7 +294,7 @@ class TestFileServices:
                 description=f"Test file {i}",
                 entity_type=EntityType.PROJECT,
                 entity_id="PROJ001",
-                file_type=FileType.DOCUMENT
+                file_type=FileType.DOCUMENT,
             )
             create_file(session, file_create, storage_root=temp_storage)
 
@@ -318,7 +316,7 @@ class TestFileServices:
                 file_create = FileCreate(
                     filename=f"test{i}.txt",
                     entity_type=EntityType.PROJECT,
-                    entity_id=entity_id
+                    entity_id=entity_id,
                 )
                 create_file(session, file_create, storage_root=temp_storage)
 
@@ -335,7 +333,7 @@ class TestFileServices:
             file_create = FileCreate(
                 filename=f"test{i}.txt",
                 entity_type=EntityType.PROJECT,
-                entity_id="PROJ001"
+                entity_id="PROJ001",
             )
             create_file(session, file_create, storage_root=temp_storage)
 
@@ -346,12 +344,12 @@ class TestFileServices:
         """Test retrieving file content"""
         content = b"Hello, World!"
         file_create = FileCreate(
-            filename="test.txt",
-            entity_type=EntityType.PROJECT,
-            entity_id="PROJ001"
+            filename="test.txt", entity_type=EntityType.PROJECT, entity_id="PROJ001"
         )
 
-        created_file = create_file(session, file_create, content, storage_root=temp_storage)
+        created_file = create_file(
+            session, file_create, content, storage_root=temp_storage
+        )
         retrieved_content = get_file_content(
             session, created_file.file_id, storage_root=temp_storage
         )
@@ -361,9 +359,7 @@ class TestFileServices:
     def test_get_file_content_not_found(self, session: Session, temp_storage):
         """Test retrieving content for non-existent file"""
         file_create = FileCreate(
-            filename="test.txt",
-            entity_type=EntityType.PROJECT,
-            entity_id="PROJ001"
+            filename="test.txt", entity_type=EntityType.PROJECT, entity_id="PROJ001"
         )
 
         # Create file record without content
@@ -387,7 +383,7 @@ class TestFileAPI:
             "entity_type": "project",
             "entity_id": "PROJ001",
             "is_public": "true",  # Form data sends as string
-            "created_by": "api_test_user"
+            "created_by": "api_test_user",
         }
 
         response = client.post("/api/v1/files", data=file_data)
@@ -414,7 +410,7 @@ class TestFileAPI:
                 "file_type": "document",
                 "entity_type": "project",
                 "entity_id": "PROJ001",
-                "created_by": "list_test_user"
+                "created_by": "list_test_user",
             }
             client.post("/api/v1/files", data=file_data)
 
@@ -468,7 +464,7 @@ class TestFileAPI:
             "file_type": "document",
             "entity_type": "project",
             "entity_id": "PROJ001",
-            "created_by": "get_test_user"
+            "created_by": "get_test_user",
         }
 
         create_response = client.post("/api/v1/files", data=file_data)
@@ -498,7 +494,7 @@ class TestFileAPI:
             "file_type": "document",
             "entity_type": "project",
             "entity_id": "PROJ001",
-            "created_by": "update_test_user"
+            "created_by": "update_test_user",
         }
 
         create_response = client.post("/api/v1/files", data=file_data)
@@ -507,10 +503,7 @@ class TestFileAPI:
         file_id = created_file["file_id"]
 
         # Test successful update
-        update_data = {
-            "description": "Updated description",
-            "is_public": True
-        }
+        update_data = {"description": "Updated description", "is_public": True}
 
         response = client.put(f"/api/v1/files/{file_id}", json=update_data)
         assert response.status_code == 200
@@ -534,7 +527,7 @@ class TestFileAPI:
             "file_type": "document",
             "entity_type": "project",
             "entity_id": "PROJ001",
-            "created_by": "delete_test_user"
+            "created_by": "delete_test_user",
         }
 
         create_response = client.post("/api/v1/files", data=file_data)
@@ -560,7 +553,7 @@ class TestFileAPI:
         entities = [
             ("project", "PROJ001"),
             ("project", "PROJ002"),
-            ("run", "190110_MACHINE123_0001_FLOWCELL123")
+            ("run", "190110_MACHINE123_0001_FLOWCELL123"),
         ]
 
         for entity_type, entity_id in entities:
@@ -571,7 +564,7 @@ class TestFileAPI:
                     "file_type": "document",
                     "entity_type": entity_type,
                     "entity_id": entity_id,
-                    "created_by": "entity_test_user"
+                    "created_by": "entity_test_user",
                 }
                 client.post("/api/v1/files", data=file_data)
 
@@ -586,7 +579,9 @@ class TestFileAPI:
             assert item["entity_id"] == "PROJ001"
 
         # Test listing files for specific run
-        response = client.get("/api/v1/files/entity/run/190110_MACHINE123_0001_FLOWCELL123")
+        response = client.get(
+            "/api/v1/files/entity/run/190110_MACHINE123_0001_FLOWCELL123"
+        )
         assert response.status_code == 200
 
         data = response.json()
@@ -603,7 +598,9 @@ class TestFileAPI:
         assert data["per_page"] == 1
         assert len(data["data"]) == 1
 
-    def test_get_file_count_for_entity_endpoint(self, client: TestClient, session: Session):
+    def test_get_file_count_for_entity_endpoint(
+        self, client: TestClient, session: Session
+    ):
         """Test getting file count for a specific entity"""
         # Create files for a specific entity
         entity_type = "project"
@@ -616,7 +613,7 @@ class TestFileAPI:
                 "file_type": "document",
                 "entity_type": entity_type,
                 "entity_id": entity_id,
-                "created_by": "count_test_user"
+                "created_by": "count_test_user",
             }
             client.post("/api/v1/files", data=file_data)
 
@@ -638,7 +635,9 @@ class TestFileAPI:
         assert data["entity_id"] == "EMPTY_PROJECT"
         assert data["file_count"] == 0
 
-    def test_create_file_with_content_endpoint(self, client: TestClient, session: Session):
+    def test_create_file_with_content_endpoint(
+        self, client: TestClient, session: Session
+    ):
         """Test file creation with content upload"""
         import io
 
@@ -649,12 +648,14 @@ class TestFileAPI:
             "file_type": "document",
             "entity_type": "project",
             "entity_id": "PROJ001",
-            "created_by": "content_test_user"
+            "created_by": "content_test_user",
         }
 
         # Create file content
         file_content = b"Hello, this is test content!"
-        files = {"content": ("test_content.txt", io.BytesIO(file_content), "text/plain")}
+        files = {
+            "content": ("test_content.txt", io.BytesIO(file_content), "text/plain")
+        }
 
         # Send multipart form data
         response = client.post("/api/v1/files", data=file_data, files=files)
@@ -672,7 +673,7 @@ class TestFileAPI:
             "filename": "test.txt",
             "file_type": "invalid_type",
             "entity_type": "project",
-            "entity_id": "PROJ001"
+            "entity_id": "PROJ001",
         }
 
         response = client.post("/api/v1/files", data=invalid_file_data)
@@ -683,7 +684,7 @@ class TestFileAPI:
             "filename": "test.txt",
             "file_type": "document",
             "entity_type": "invalid_entity",
-            "entity_id": "PROJ001"
+            "entity_id": "PROJ001",
         }
 
         response = client.post("/api/v1/files", data=invalid_entity_data)
@@ -711,10 +712,12 @@ class TestFileIntegration:
             file_type=FileType.DOCUMENT,
             entity_type=EntityType.PROJECT,
             entity_id="PROJ001",
-            created_by="testuser"
+            created_by="testuser",
         )
 
-        created_file = create_file(session, file_create, content, storage_root=temp_storage)
+        created_file = create_file(
+            session, file_create, content, storage_root=temp_storage
+        )
         assert created_file.filename == "lifecycle.txt"
         assert created_file.file_size == len(content)
 
@@ -729,8 +732,7 @@ class TestFileIntegration:
 
         # Update file metadata
         file_update = FileUpdate(
-            description="Updated lifecycle test file",
-            is_public=True
+            description="Updated lifecycle test file", is_public=True
         )
 
         updated_file = update_file(session, created_file.file_id, file_update)
@@ -750,7 +752,7 @@ class TestFileIntegration:
         entities = [
             (EntityType.PROJECT, "PROJ001"),
             (EntityType.PROJECT, "PROJ002"),
-            (EntityType.RUN, "190110_MACHINE123_0001_FLOWCELL123")
+            (EntityType.RUN, "190110_MACHINE123_0001_FLOWCELL123"),
         ]
 
         created_files = []
@@ -762,10 +764,12 @@ class TestFileIntegration:
                     filename=f"file{i}.txt",
                     entity_type=entity_type,
                     entity_id=entity_id,
-                    file_type=FileType.DOCUMENT
+                    file_type=FileType.DOCUMENT,
                 )
 
-                file_record = create_file(session, file_create, storage_root=temp_storage)
+                file_record = create_file(
+                    session, file_create, storage_root=temp_storage
+                )
                 created_files.append(file_record)
 
         # Verify total count
@@ -790,13 +794,14 @@ class TestFileIntegration:
                 filename=f"test.{file_type.value}",
                 entity_type=EntityType.PROJECT,
                 entity_id="PROJ001",
-                file_type=file_type
+                file_type=file_type,
             )
             create_file(session, file_create, storage_root=temp_storage)
 
         # Test filtering by each type
         for file_type in file_types:
             from api.files.models import FileFilters
+
             filters = FileFilters(file_type=file_type)
             result = list_files(session, filters=filters)
 
@@ -809,22 +814,17 @@ class TestFileBrowserModels:
 
     def test_file_browser_folder_model(self):
         """Test FileBrowserFolder model"""
-        folder = FileBrowserFolder(
-            name="test_folder",
-            date="2023-01-01 12:00:00"
-        )
-        
+        folder = FileBrowserFolder(name="test_folder", date="2023-01-01 12:00:00")
+
         assert folder.name == "test_folder"
         assert folder.date == "2023-01-01 12:00:00"
 
     def test_file_browser_file_model(self):
         """Test FileBrowserFile model"""
         file = FileBrowserFile(
-            name="test_file.txt",
-            date="2023-01-01 12:00:00",
-            size=1024
+            name="test_file.txt", date="2023-01-01 12:00:00", size=1024
         )
-        
+
         assert file.name == "test_file.txt"
         assert file.date == "2023-01-01 12:00:00"
         assert file.size == 1024
@@ -833,12 +833,9 @@ class TestFileBrowserModels:
         """Test FileBrowserData model"""
         folder = FileBrowserFolder(name="folder1", date="2023-01-01 12:00:00")
         file = FileBrowserFile(name="file1.txt", date="2023-01-01 12:00:00", size=100)
-        
-        browser_data = FileBrowserData(
-            folders=[folder],
-            files=[file]
-        )
-        
+
+        browser_data = FileBrowserData(folders=[folder], files=[file])
+
         assert len(browser_data.folders) == 1
         assert len(browser_data.files) == 1
         assert browser_data.folders[0].name == "folder1"
@@ -852,36 +849,36 @@ class TestFileBrowserServices:
     def temp_storage(self):
         """Create temporary storage with folder/file structure"""
         temp_dir = tempfile.mkdtemp()
-        
+
         # Create some folders
         (Path(temp_dir) / "folder1").mkdir()
         (Path(temp_dir) / "folder2").mkdir()
-        
+
         # Create some files
         (Path(temp_dir) / "file1.txt").write_text("content1")
         (Path(temp_dir) / "file2.txt").write_text("content2")
-        
+
         yield temp_dir
         shutil.rmtree(temp_dir)
 
     def test_browse_filesystem(self, temp_storage):
         """Test filesystem browsing"""
         result = browse_filesystem("", temp_storage)
-        
+
         assert isinstance(result, FileBrowserData)
         assert len(result.folders) == 2
         assert len(result.files) == 2
-        
+
         # Check folder names
         folder_names = [f.name for f in result.folders]
         assert "folder1" in folder_names
         assert "folder2" in folder_names
-        
+
         # Check file names
         file_names = [f.name for f in result.files]
         assert "file1.txt" in file_names
         assert "file2.txt" in file_names
-        
+
         # Check file sizes
         for file in result.files:
             assert file.size > 0
@@ -891,7 +888,7 @@ class TestFileBrowserServices:
         """Test browsing non-existent directory"""
         with pytest.raises(HTTPException) as exc_info:
             browse_filesystem("nonexistent", "nonexistent_root")
-        
+
         assert exc_info.value.status_code == 404
         assert "not found" in str(exc_info.value.detail)
 
@@ -904,17 +901,17 @@ class TestFileBrowserServices:
                 description=f"Database file {i}",
                 entity_type=EntityType.PROJECT,
                 entity_id="PROJ001",
-                file_type=FileType.DOCUMENT
+                file_type=FileType.DOCUMENT,
             )
             create_file(session, file_create)
 
         # Get files in browser format
         result = list_files_as_browser_data(session)
-        
+
         assert isinstance(result, FileBrowserData)
         assert len(result.folders) == 0  # No folders for database files
         assert len(result.files) == 3
-        
+
         # Check file properties
         for file in result.files:
             assert file.name.startswith("db_file_")
@@ -933,17 +930,17 @@ class TestFileBrowserAPI:
             # Create test structure
             (Path(temp_dir) / "test_folder").mkdir()
             (Path(temp_dir) / "test_file.txt").write_text("test content")
-            
+
             # Test the endpoint
             response = client.get(f"/api/v1/files/browse?storage_root={temp_dir}")
             assert response.status_code == 200
-            
+
             data = response.json()
             assert "folders" in data
             assert "files" in data
             assert isinstance(data["folders"], list)
             assert isinstance(data["files"], list)
-            
+
         finally:
             shutil.rmtree(temp_dir)
 
@@ -957,20 +954,20 @@ class TestFileBrowserAPI:
                 "file_type": "document",
                 "entity_type": "project",
                 "entity_id": "PROJ001",
-                "created_by": "browser_test_user"
+                "created_by": "browser_test_user",
             }
             client.post("/api/v1/files", data=file_data)
 
         # Test the browser endpoint
         response = client.get("/api/v1/files/browse-db")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert "folders" in data
         assert "files" in data
         assert len(data["folders"]) == 0  # No folders for database files
         assert len(data["files"]) >= 2
-        
+
         # Check file structure
         for file in data["files"]:
             assert "name" in file
@@ -984,4 +981,3 @@ class TestFileBrowserAPI:
             "/api/v1/files/browse?directory_path=nonexistent&storage_root=nonexistent"
         )
         assert response.status_code == 404
-

--- a/tests/api/test_files.py
+++ b/tests/api/test_files.py
@@ -804,7 +804,6 @@ class TestFileIntegration:
             assert result.data[0].file_type == file_type
 
 
-
 class TestFileBrowserModels:
     """Test file browser model functionality"""
 
@@ -926,7 +925,7 @@ class TestFileBrowserServices:
 class TestFileBrowserAPI:
     """Test file browser API endpoints"""
 
-    def test_browse_filesystem_endpoint(self, client: TestClient, temp_storage):
+    def test_browse_filesystem_endpoint(self, client: TestClient):
         """Test filesystem browsing endpoint"""
         # Create a temporary directory structure for testing
         temp_dir = tempfile.mkdtemp()

--- a/tests/api/test_files.py
+++ b/tests/api/test_files.py
@@ -947,27 +947,27 @@ class TestFileBrowserAPI:
     def test_s3_path_detection(self):
         """Test S3 path detection functionality"""
         from api.files.services import _is_s3_path, _parse_s3_path
-        
+
         # Test S3 path detection
         assert _is_s3_path("s3://bucket/key") is True
         assert _is_s3_path("s3://bucket") is True
         assert _is_s3_path("/local/path") is False
         assert _is_s3_path("local/path") is False
         assert _is_s3_path("") is False
-        
+
         # Test S3 path parsing
         bucket, key = _parse_s3_path("s3://my-bucket/path/to/folder/")
         assert bucket == "my-bucket"
         assert key == "path/to/folder/"
-        
+
         bucket, key = _parse_s3_path("s3://my-bucket")
         assert bucket == "my-bucket"
         assert key == ""
-        
+
         bucket, key = _parse_s3_path("s3://my-bucket/")
         assert bucket == "my-bucket"
         assert key == ""
-        
+
         # Test invalid S3 path
         with pytest.raises(ValueError):
             _parse_s3_path("invalid://path")
@@ -976,8 +976,9 @@ class TestFileBrowserAPI:
         """Test S3 browsing when boto3 is not available"""
         # Mock BOTO3_AVAILABLE to False
         import api.files.services as services
+
         monkeypatch.setattr(services, "BOTO3_AVAILABLE", False)
-        
+
         response = client.get("/api/v1/files/browse?directory_path=s3://test-bucket/")
         assert response.status_code == 501
         assert "S3 support not available" in response.json()["detail"]


### PR DESCRIPTION
## New Models Added ([`api/files/models.py`](api/files/models.py:180-204))

1. **`FileBrowserColumns`** - Individual file/folder item with `name`, `date`, `size`, and `dir` properties
2. **`FileBrowserFolder`** - Folder item with `name` and `date`
3. **`FileBrowserFile`** - File item with `name`, `date`, and `size`
4. **`FileBrowserData`** - Main structure with separate `folders` and `files` arrays

## New Service Functions ([`api/files/services.py`](api/files/services.py:372-456))

1. **`browse_filesystem()`** - Browse actual filesystem directories and return structured data
2. **`list_files_as_browser_data()`** - Convert database files to FileBrowserData format

## New API Endpoints ([`api/files/routes.py`](api/files/routes.py:108-157))

1. **`GET /api/v1/files/browse`** - Browse filesystem directories
   - Parameters: `directory_path`, `storage_root`
   - Returns: `FileBrowserData` with folders and files from filesystem

2. **`GET /api/v1/files/browse-db`** - List database files in browser format
   - Same filtering parameters as regular list_files endpoint
   - Returns: `FileBrowserData` format (files only, no folders)

## Usage Examples

**Browse filesystem:**
```bash
GET /api/v1/files/browse?directory_path=project/PROJ001/document/2025/09&storage_root=storage
```

**Browse database files:**
```bash
GET /api/v1/files/browse-db?entity_type=project&entity_id=PROJ001
```

Both endpoints return data in your requested structure:
```json
{
  "folders": [
    {"name": "folder1", "date": "2023-01-01 12:00:00"}
  ],
  "files": [
    {"name": "file1.txt", "date": "2023-01-01 12:00:00", "size": 1024}
  ]
}
```

The implementation includes comprehensive tests and handles error cases like non-existent directories and permission issues. The filesystem browser sorts items alphabetically and provides proper date formatting.