### PR TITLE
expose sample uuid on creation for association to runs

### DIFF
--- a/api/project/services.py
+++ b/api/project/services.py
@@ -670,6 +670,7 @@ def get_project_samples(
     # Map to public samples
     public_samples = [
         SamplePublic(
+            id=sample.id,
             sample_id=sample.sample_id,
             project_id=sample.project_id,
             attributes=sample.attributes,
@@ -755,6 +756,7 @@ def update_sample_in_project(
     session.refresh(sample)
 
     return SamplePublic(
+        id=sample.id,
         sample_id=sample.sample_id,
         project_id=sample.project_id,
         attributes=[

--- a/api/samples/models.py
+++ b/api/samples/models.py
@@ -49,6 +49,7 @@ class SampleCreate(SQLModel):
 
 
 class SamplePublic(SQLModel):
+    id: uuid.UUID
     sample_id: str
     project_id: str
     attributes: List[Attribute] | None

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -154,6 +154,10 @@ def test_add_sample_to_project(client: TestClient, session: Session):
     )
     assert response.status_code == 201
     assert response.json()["sample_id"] == "Sample_1"
+    assert "id" in response.json()
+    # Verify the id is a valid UUID string
+    import uuid
+    uuid.UUID(response.json()["id"])
 
 
 def test_fail_to_add__sample_with_duplicate_attributes(


### PR DESCRIPTION
This PR address #186 with the following changes:
1. Changes samplepublic to include the uuid
2. updates affected get_project_samples() function
3. updates tests