### PR TITLE
Fix how we fetch job logs

### DIFF
--- a/api/jobs/routes.py
+++ b/api/jobs/routes.py
@@ -11,6 +11,7 @@ PUT    /api/v1/jobs/[id]    Update a batch job
 
 from typing import Optional, Literal
 from fastapi import APIRouter, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
 from core.deps import SessionDep
 from api.jobs.models import (
     BatchJobSubmit,
@@ -124,6 +125,9 @@ def get_jobs(
     "/{job_id}",
     response_model=BatchJobPublic,
     tags=["Job Endpoints"],
+    responses={
+        404: {"description": "Job not found"}
+    }
 )
 def get_job(
     session: SessionDep,
@@ -152,6 +156,9 @@ def get_job(
     "/{job_id}",
     response_model=BatchJobPublic,
     tags=["Job Endpoints"],
+    responses={
+        404: {"description": "Job not found"}
+    }
 )
 def update_job(
     session: SessionDep,
@@ -180,24 +187,41 @@ def update_job(
     return BatchJobPublic.model_validate(updated_job)
 
 
+###############################################################################
+# Job Endpoints /api/v1/jobs/{job_id}/log
+###############################################################################
+
+
 @router.get(
     "/{job_id}/log",
-    response_model=list[str],
+    response_class=StreamingResponse,
     tags=["Job Endpoints"],
+    responses={
+        404: {"description": "Job or log stream not found"}
+    }
 )
 def get_job_log(
     session: SessionDep,
-    job_id: str,
-) -> list[str]:
+    job_id: str
+) -> StreamingResponse:
     """
-    Retrieve log for a specific batch job.
+    Stream log for a specific batch job.
 
     Args:
         session: Database session
         job_id: Job UUID
 
     Returns:
-        List of log lines
+        Stream of log lines for the specified job
+
+    Raises:
+        HTTPException: If job or log stream not found
     """
-    logs = services.get_batch_job_log(session, job_id)
-    return logs
+    job = services.get_batch_job(session, job_id)
+    if not job or not job.log_stream_name:
+        raise HTTPException(status_code=404, detail="Job or log not found")
+
+    return StreamingResponse(
+        services.stream_batch_job_log(job.log_stream_name),
+        media_type="text/plain"
+    )

--- a/api/jobs/services.py
+++ b/api/jobs/services.py
@@ -232,3 +232,34 @@ def get_log_events(log_group, log_stream_name, start_time=None, end_time=None):
             break
         kwargs['nextToken'] = next_forward_token
     return events
+
+
+def stream_batch_job_log(log_stream_name: str):
+    """Stream log events to avoid memory buildup and timeouts."""
+    log_group = "/aws/batch/job"
+    settings = get_settings()
+
+    # Create client ONCE outside loop
+    logs_client = boto3.client('logs', region_name=settings.AWS_REGION)
+
+    kwargs = {
+        'logGroupName': log_group,
+        'logStreamName': log_stream_name,
+        'limit': 1000,  # Smaller batches for faster initial response
+        'startFromHead': True,
+    }
+
+    try:
+        while True:
+            resp = logs_client.get_log_events(**kwargs)
+
+            for event in resp['events']:
+                yield event['message'] + '\n'
+
+            next_token = resp.get('nextForwardToken')
+            if not next_token or kwargs.get('nextToken') == next_token:
+                break
+            kwargs['nextToken'] = next_token
+
+    except botocore.exceptions.ClientError as e:
+        yield f"Error retrieving logs: {str(e)}\n"

--- a/api/jobs/services.py
+++ b/api/jobs/services.py
@@ -4,7 +4,6 @@ Services for managing batch jobs.
 from typing import Any, List, Dict, Literal
 from sqlmodel import select, Session, func
 from fastapi import HTTPException, status
-import uuid
 import boto3
 import botocore
 from core.config import get_settings
@@ -175,63 +174,63 @@ def submit_batch_job(
     return job
 
 
-def get_batch_job_log(session: Session, job_id: uuid.UUID) -> list[str]:
-    """
-    Retrieve the log output for a batch job.
+# def get_batch_job_log(session: Session, job_id: uuid.UUID) -> list[str]:
+#     """
+#     Retrieve the log output for a batch job.
 
-    Args:
-        session: Database session
-        job_id: Job UUID
-    Returns:
-        Log output as a list of strings
-    """
-    job = session.get(BatchJob, job_id)
+#     Args:
+#         session: Database session
+#         job_id: Job UUID
+#     Returns:
+#         Log output as a list of strings
+#     """
+#     job = session.get(BatchJob, job_id)
 
-    if not job or not job.log_stream_name:
-        logger.warning(f"Job {job_id} not available or does not have a log stream name")
-        return []
+#     if not job or not job.log_stream_name:
+#         logger.warning(f"Job {job_id} not available or does not have a log stream name")
+#         return []
 
-    log_group = "/aws/batch/job"
-    log_stream_name = job.log_stream_name
+#     log_group = "/aws/batch/job"
+#     log_stream_name = job.log_stream_name
 
-    logger.info(f"Retrieving logs for job {job_id} from log group '{log_group}' "
-                f"and stream '{log_stream_name}'")
-    return get_log_events(log_group, log_stream_name)
+#     logger.info(f"Retrieving logs for job {job_id} from log group '{log_group}' "
+#                 f"and stream '{log_stream_name}'")
+#     return get_log_events(log_group, log_stream_name)
 
 
-def get_log_events(log_group, log_stream_name, start_time=None, end_time=None):
-    """
-    List events from CloudWatch log
-    """
-    kwargs = {
-        'logGroupName': log_group,
-        'logStreamName': log_stream_name,
-        'limit': 10000,
-        'startFromHead': True,
-    }
+# def get_log_events(log_group, log_stream_name, start_time=None, end_time=None):
+#     """
+#     List events from CloudWatch log
+#     """
+#     kwargs = {
+#         'logGroupName': log_group,
+#         'logStreamName': log_stream_name,
+#         'limit': 10000,
+#         'startFromHead': True,
+#     }
 
-    if start_time:
-        kwargs['startTime'] = start_time
-    if end_time:
-        kwargs['endTime'] = end_time
+#     if start_time:
+#         kwargs['startTime'] = start_time
+#     if end_time:
+#         kwargs['endTime'] = end_time
 
-    events = []
-    while True:
-        try:
-            resp = boto3.client(
-                'logs',
-                region_name=get_settings().AWS_REGION
-            ).get_log_events(**kwargs)
-        except botocore.exceptions.ClientError:
-            return ["No log (yet) available"]
-        for event in resp['events']:
-            events.append(event['message'])
+#     events = []
+#     while True:
+#         try:
+#             resp = boto3.client(
+#                 'logs',
+#                 region_name=get_settings().AWS_REGION
+#             ).get_log_events(**kwargs)
+#         except botocore.exceptions.ClientError:
+#             return ["No log (yet) available"]
+#         for event in resp['events']:
+#             events.append(event['message'])
 
-        next_forward_token = resp.get('nextForwardToken')
-        if not next_forward_token or kwargs.get('nextToken') == next_forward_token:
-            break
-        kwargs['nextToken'] = next_forward_token
-    return events
+#         next_forward_token = resp.get('nextForwardToken')
+#         if not next_forward_token or kwargs.get('nextToken') == next_forward_token:
+#             break
+#         kwargs['nextToken'] = next_forward_token
+#     return events
 
 
 def stream_batch_job_log(log_stream_name: str):
@@ -249,6 +248,7 @@ def stream_batch_job_log(log_stream_name: str):
         'startFromHead': True,
     }
 
+    logger.info(f"Starting log stream for {log_stream_name}")
     try:
         while True:
             resp = logs_client.get_log_events(**kwargs)
@@ -263,3 +263,5 @@ def stream_batch_job_log(log_stream_name: str):
 
     except botocore.exceptions.ClientError as e:
         yield f"Error retrieving logs: {str(e)}\n"
+
+    logger.info(f"Completed log stream for {log_stream_name}")

--- a/api/jobs/services.py
+++ b/api/jobs/services.py
@@ -250,15 +250,39 @@ def stream_batch_job_log(log_stream_name: str):
 
     logger.info(f"Starting log stream for {log_stream_name}")
     try:
+        consecutive_empty = 0
+        max_empty_attempts = 3  # Stop after 3 consecutive empty responses
+
         while True:
             resp = logs_client.get_log_events(**kwargs)
+            events = resp.get('events', [])
 
-            for event in resp['events']:
-                yield event['message'] + '\n'
+            # Yield all events
+            if events:
+                consecutive_empty = 0  # Reset counter on new events
+                for event in events:
+                    yield event['message'] + '\n'
+            else:
+                consecutive_empty += 1
+                logger.debug(f"Empty response #{consecutive_empty} for {log_stream_name}")
 
+                # Stop if we get too many empty responses
+                if consecutive_empty >= max_empty_attempts:
+                    logger.info(f"No more events after {consecutive_empty} attempts")
+                    break
+
+            # Check pagination token for next batch
             next_token = resp.get('nextForwardToken')
-            if not next_token or kwargs.get('nextToken') == next_token:
+            prev_token = kwargs.get('nextToken')
+            logger.debug(f"prev_token={prev_token}, next_token={next_token}")
+
+            # Exit conditions:
+            # 1. No next token provided
+            # 2. Token hasn't changed (no more data)
+            if not next_token or prev_token == next_token:
+                logger.info("Pagination complete (token unchanged)")
                 break
+
             kwargs['nextToken'] = next_token
 
     except botocore.exceptions.ClientError as e:


### PR DESCRIPTION
get_job_log wasn't returned AWS CloudWatch logs.  There were a few issues identified by Claude:

Performance Issues
1. Synchronous Blocking I/O
The get_log_events() function makes synchronous boto3 calls to CloudWatch Logs, which blocks the entire request thread while waiting for AWS responses.

2. Fetching All Logs at Once
Lines 219-234 in services.py fetch ALL log events in a while loop until exhausted. For large jobs with millions of log lines, this causes:

Memory accumulation (all logs stored in events list)
Extended processing time (multiple AWS API calls in sequence)
Gateway timeout before response can be sent

3. Inefficient boto3 Client Creation
Line 221-224 creates a new boto3 client inside the while loop on every iteration, adding unnecessary overhead.

4. No Pagination Support
The API endpoint doesn't support pagination - clients must wait for the entire log file, even if they only need recent entries.

5. No Caching
Logs for completed jobs never change, but they're fetched from CloudWatch every time.


@EricSDavis  - I ended up implementing a StreamingResponse which seems to be the best solution here, however the FrontEnd still isn't displaying anything.