### PR TITLE
Feature nwp 2119 sample run association and bulk submission

### DIFF
--- a/api/project/routes.py
+++ b/api/project/routes.py
@@ -14,8 +14,16 @@ from api.project.models import (
     ProjectPublic,
     ProjectsPublic,
 )
-from api.samples.models import SampleCreate, SamplePublic, SamplesPublic, Attribute
+from api.samples.models import (
+    SampleCreate,
+    SamplePublic,
+    SamplesPublic,
+    Attribute,
+    BulkSampleCreateRequest,
+    BulkSampleCreateResponse,
+)
 from api.project import services
+from api.samples import services as sample_services
 from api.actions.models import ActionSubmitRequest
 
 router = APIRouter(prefix="/projects")
@@ -178,15 +186,58 @@ def add_sample_to_project(
     opensearch_client: OpenSearchDep,
     project: ProjectDep,
     sample_in: SampleCreate,
+    current_user: CurrentUser,
 ) -> SamplePublic:
     """
     Create a new sample with optional attributes.
+
+    If ``run_barcode`` is provided in the request body, the sample is also
+    associated with the specified sequencing run in the same transaction.
     """
-    return services.add_sample_to_project(
+    sample = services.add_sample_to_project(
         session=session,
         opensearch_client=opensearch_client,
         project=project,
         sample_in=sample_in,
+        created_by=current_user.username,
+    )
+    return SamplePublic(
+        sample_id=sample.sample_id,
+        project_id=sample.project_id,
+        attributes=[
+            Attribute(key=a.key, value=a.value)
+            for a in (sample.attributes or [])
+        ],
+        run_barcode=sample_in.run_barcode,
+    )
+
+
+@router.post(
+    "/{project_id}/samples/bulk",
+    tags=["Project Endpoints"],
+    status_code=status.HTTP_201_CREATED,
+    response_model=BulkSampleCreateResponse,
+)
+def bulk_create_samples(
+    session: SessionDep,
+    opensearch_client: OpenSearchDep,
+    project: ProjectDep,
+    current_user: CurrentUser,
+    body: BulkSampleCreateRequest,
+) -> BulkSampleCreateResponse:
+    """
+    Create multiple samples in a single atomic transaction.
+
+    Each sample in the list may optionally include a ``run_barcode``
+    to associate the sample with a sequencing run at creation time.
+    All samples succeed or fail together.
+    """
+    return sample_services.bulk_create_samples(
+        session=session,
+        opensearch_client=opensearch_client,
+        project=project,
+        samples_in=body.samples,
+        created_by=current_user.username,
     )
 
 

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -567,19 +567,39 @@ def add_sample_to_project(
     opensearch_client: OpenSearch,
     project: Project,
     sample_in: SampleCreate,
+    created_by: str | None = None,
 ) -> Sample:
     """
     Create a new sample with optional attributes in a project.
+
+    If ``sample_in.run_barcode`` is provided the sample is also associated
+    with the corresponding sequencing run in the **same** transaction.
 
     Args:
         session: Database session
         opensearch_client: OpenSearch client for indexing
         project: The project object (already validated)
-        sample_in: Sample creation data
+        sample_in: Sample creation data (may include run_barcode)
+        created_by: Username recorded on any SampleSequencingRun row
 
     Returns:
         Sample instance
     """
+    from api.runs.services import get_run
+
+    # Resolve run up-front so we can fail fast before creating the sample
+    run = None
+    if sample_in.run_barcode:
+        try:
+            run = get_run(session=session, run_barcode=sample_in.run_barcode)
+        except (ValueError, Exception):
+            run = None
+        if run is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Run with barcode '{sample_in.run_barcode}' not found.",
+            )
+
     # Create initial sample
     sample = Sample(sample_id=sample_in.sample_id, project_id=project.project_id)
     session.add(sample)
@@ -605,6 +625,15 @@ def add_sample_to_project(
 
         # Update database with attribute links
         session.add_all(sample_attributes)
+
+    # Associate with sequencing run if requested
+    if run is not None:
+        assoc = SampleSequencingRun(
+            sample_id=sample.id,
+            sequencing_run_id=run.id,
+            created_by=created_by or "api",
+        )
+        session.add(assoc)
 
     session.commit()
     session.refresh(sample)

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -638,10 +638,13 @@ def add_sample_to_project(
     session.commit()
     session.refresh(sample)
 
-    # Add sample to opensearch
+    # Add sample to opensearch (best-effort; DB is source of truth)
     if opensearch_client:
         search_doc = SearchDocument(id=str(sample.id), body=sample)
-        add_object_to_index(opensearch_client, search_doc, index="samples")
+        try:
+            add_object_to_index(opensearch_client, search_doc, index="samples")
+        except Exception:
+            pass  # best-effort indexing; can be resynced via /reindex
 
     return sample
 

--- a/api/samples/models.py
+++ b/api/samples/models.py
@@ -5,7 +5,7 @@ Models for the Sample API
 import uuid
 from typing import List, TYPE_CHECKING
 from sqlmodel import SQLModel, Field, Relationship, UniqueConstraint
-from pydantic import ConfigDict
+from pydantic import ConfigDict, field_validator
 
 if TYPE_CHECKING:
     from api.project.models import Project
@@ -45,6 +45,7 @@ class Sample(SQLModel, table=True):
 class SampleCreate(SQLModel):
     sample_id: str
     attributes: List[Attribute] | None = None
+    run_barcode: str | None = None
     model_config = ConfigDict(extra="forbid")
 
 
@@ -52,6 +53,7 @@ class SamplePublic(SQLModel):
     sample_id: str
     project_id: str
     attributes: List[Attribute] | None
+    run_barcode: str | None = None
 
 
 class SamplesPublic(SQLModel):
@@ -63,3 +65,39 @@ class SamplesPublic(SQLModel):
     per_page: int
     has_next: bool
     has_prev: bool
+
+
+# ---------------------------------------------------------------------------
+# Bulk sample creation models
+# ---------------------------------------------------------------------------
+
+
+class BulkSampleCreateRequest(SQLModel):
+    """Request body for POST /projects/{project_id}/samples/bulk."""
+    samples: List[SampleCreate]
+
+    @field_validator("samples")
+    @classmethod
+    def samples_must_not_be_empty(cls, v: List[SampleCreate]) -> List[SampleCreate]:
+        if not v:
+            raise ValueError("samples list must not be empty")
+        return v
+
+
+class BulkSampleItemResponse(SQLModel):
+    """Per-item detail in the bulk creation response."""
+    sample_id: str
+    sample_uuid: uuid.UUID
+    project_id: str
+    created: bool
+    run_barcode: str | None = None
+
+
+class BulkSampleCreateResponse(SQLModel):
+    """Aggregate response for the bulk sample creation endpoint."""
+    project_id: str
+    samples_created: int
+    samples_existing: int
+    associations_created: int
+    associations_existing: int
+    items: List[BulkSampleItemResponse]

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -1,20 +1,23 @@
 import uuid
+from typing import List, Literal
 
 from fastapi import HTTPException, status
-from typing import Literal
 from pydantic import PositiveInt
-
 from sqlmodel import Session, select, func
-
+from opensearchpy import OpenSearch
 
 from api.samples.models import (
-    Sample, SampleCreate, SamplePublic, SamplesPublic, SampleAttribute
+    Sample,
+    SampleCreate,
+    SamplePublic,
+    SamplesPublic,
+    SampleAttribute,
+    BulkSampleCreateResponse,
+    BulkSampleItemResponse,
 )
 from api.project.models import Project
-from api.search.models import (
-    SearchDocument,
-)
-from opensearchpy import OpenSearch
+from api.runs.models import SequencingRun, SampleSequencingRun
+from api.search.models import SearchDocument
 from api.search.services import add_object_to_index, delete_index
 
 
@@ -230,3 +233,199 @@ def reindex_samples(session: Session, client: OpenSearch):
     for sample in samples:
         search_doc = SearchDocument(id=str(sample.id), body=sample)
         add_object_to_index(client, search_doc, index="samples")
+
+
+# ---------------------------------------------------------------------------
+# Bulk sample creation
+# ---------------------------------------------------------------------------
+
+
+def bulk_create_samples(
+    session: Session,
+    opensearch_client: OpenSearch,
+    project: Project,
+    samples_in: List[SampleCreate],
+    created_by: str,
+) -> BulkSampleCreateResponse:
+    """
+    Create multiple samples in a single atomic transaction.
+
+    Each item may optionally include a ``run_barcode`` to associate
+    the sample with a sequencing run at creation time.
+
+    All database writes happen in one transaction — if anything fails
+    the entire batch is rolled back.
+
+    Args:
+        session: Database session
+        opensearch_client: OpenSearch client for indexing
+        project: The project object (already validated by route dependency)
+        samples_in: List of SampleCreate items
+        created_by: Username recorded on any SampleSequencingRun rows
+
+    Returns:
+        BulkSampleCreateResponse with per-item details and aggregate counts
+    """
+    from api.runs.services import get_run
+
+    # ── Pre-validation ────────────────────────────────────────────────
+
+    # 1. Check for duplicate sample_ids within the request
+    seen_ids: set[str] = set()
+    duplicates: list[str] = []
+    for item in samples_in:
+        if item.sample_id in seen_ids:
+            duplicates.append(item.sample_id)
+        seen_ids.add(item.sample_id)
+    if duplicates:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Duplicate sample_id(s) in request: "
+                f"{', '.join(sorted(set(duplicates)))}"
+            ),
+        )
+
+    # 2. Resolve all unique run barcodes up-front
+    unique_barcodes = {
+        item.run_barcode for item in samples_in if item.run_barcode
+    }
+    barcode_to_run: dict[str, SequencingRun] = {}
+    invalid_barcodes: list[str] = []
+    for barcode in unique_barcodes:
+        try:
+            run = get_run(session=session, run_barcode=barcode)
+        except (ValueError, Exception):
+            run = None
+        if run is None:
+            invalid_barcodes.append(barcode)
+        else:
+            barcode_to_run[barcode] = run
+
+    if invalid_barcodes:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Run barcode(s) not found: "
+                f"{', '.join(sorted(invalid_barcodes))}"
+            ),
+        )
+
+    # 3. Validate no duplicate attribute keys per sample
+    for item in samples_in:
+        if item.attributes:
+            seen_keys: set[str] = set()
+            dup_keys: list[str] = []
+            for attr in item.attributes:
+                if attr.key in seen_keys:
+                    dup_keys.append(attr.key)
+                seen_keys.add(attr.key)
+            if dup_keys:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Duplicate attribute keys ({', '.join(dup_keys)}) "
+                        f"on sample '{item.sample_id}'."
+                    ),
+                )
+
+    # ── Transactional creation ────────────────────────────────────────
+
+    samples_created = 0
+    samples_existing = 0
+    associations_created = 0
+    associations_existing = 0
+    items: list[BulkSampleItemResponse] = []
+    newly_created_samples: list[Sample] = []
+
+    for item in samples_in:
+        created = False
+
+        # Resolve or create the sample
+        existing = session.exec(
+            select(Sample).where(
+                Sample.sample_id == item.sample_id,
+                Sample.project_id == project.project_id,
+            )
+        ).first()
+
+        if existing:
+            sample = existing
+            samples_existing += 1
+        else:
+            sample = Sample(
+                sample_id=item.sample_id,
+                project_id=project.project_id,
+            )
+            session.add(sample)
+            session.flush()  # get the UUID
+
+            # Create attributes
+            if item.attributes:
+                attrs = [
+                    SampleAttribute(
+                        sample_id=sample.id, key=a.key, value=a.value
+                    )
+                    for a in item.attributes
+                ]
+                session.add_all(attrs)
+
+            samples_created += 1
+            created = True
+            newly_created_samples.append(sample)
+
+        # Associate with sequencing run if requested
+        run_barcode_echo: str | None = None
+        if item.run_barcode:
+            run = barcode_to_run[item.run_barcode]
+            existing_assoc = session.exec(
+                select(SampleSequencingRun).where(
+                    SampleSequencingRun.sample_id == sample.id,
+                    SampleSequencingRun.sequencing_run_id == run.id,
+                )
+            ).first()
+
+            if existing_assoc:
+                associations_existing += 1
+            else:
+                assoc = SampleSequencingRun(
+                    sample_id=sample.id,
+                    sequencing_run_id=run.id,
+                    created_by=created_by,
+                )
+                session.add(assoc)
+                associations_created += 1
+
+            run_barcode_echo = item.run_barcode
+
+        items.append(
+            BulkSampleItemResponse(
+                sample_id=item.sample_id,
+                sample_uuid=sample.id,
+                project_id=project.project_id,
+                created=created,
+                run_barcode=run_barcode_echo,
+            )
+        )
+
+    # Single commit — all or nothing
+    session.commit()
+
+    # ── Post-commit: index newly created samples in OpenSearch ────────
+    if opensearch_client:
+        for sample in newly_created_samples:
+            session.refresh(sample)
+            search_doc = SearchDocument(id=str(sample.id), body=sample)
+            try:
+                add_object_to_index(opensearch_client, search_doc, index="samples")
+            except Exception:
+                pass  # best-effort indexing
+
+    return BulkSampleCreateResponse(
+        project_id=project.project_id,
+        samples_created=samples_created,
+        samples_existing=samples_existing,
+        associations_created=associations_created,
+        associations_existing=associations_existing,
+        items=items,
+    )

--- a/docs/SAMPLE_RUN_ASSOCIATIONS.md
+++ b/docs/SAMPLE_RUN_ASSOCIATIONS.md
@@ -76,6 +76,124 @@ A new nullable `platform` column was added to `SequencingRun` to record the sequ
 
 All endpoints require authentication. The authenticated user's username is recorded as `created_by`.
 
+### Project-Side Sample Creation (with optional run association)
+
+These endpoints are nested under the `/projects` router and combine sample creation with run association in a single request.
+
+#### Create Single Sample
+
+```
+POST /projects/{project_id}/samples
+```
+
+**Request Body:**
+
+```json
+{
+  "sample_id": "Sample_001",
+  "run_barcode": "240315_A00001_0001_BHXXXXXXX",
+  "attributes": [
+    { "key": "tissue", "value": "liver" }
+  ]
+}
+```
+
+The `run_barcode` and `attributes` fields are optional. When `run_barcode` is provided, a `SampleSequencingRun` association is created in the same transaction — eliminating the need for a separate `POST /runs/{barcode}/samples` call.
+
+**Response** (`200 OK`):
+
+```json
+{
+  "sample_id": "Sample_001",
+  "project_id": "PRJ-0042",
+  "attributes": [
+    { "key": "tissue", "value": "liver" }
+  ],
+  "run_barcode": "240315_A00001_0001_BHXXXXXXX"
+}
+```
+
+**Error** (`404 Not Found`): If `run_barcode` is provided but no matching run exists.
+**Error** (`400 Bad Request`): If duplicate attribute keys are provided.
+
+#### Bulk Create Samples
+
+```
+POST /projects/{project_id}/samples/bulk
+```
+
+Creates multiple samples in a single atomic transaction. All database writes succeed or the entire batch is rolled back.
+
+**Request Body:**
+
+```json
+{
+  "samples": [
+    {
+      "sample_id": "Sample_001",
+      "run_barcode": "240315_A00001_0001_BHXXXXXXX",
+      "attributes": [{ "key": "tissue", "value": "liver" }]
+    },
+    {
+      "sample_id": "Sample_002",
+      "run_barcode": "240315_A00001_0001_BHXXXXXXX"
+    },
+    {
+      "sample_id": "Sample_003"
+    }
+  ]
+}
+```
+
+Each item's `run_barcode` and `attributes` are optional. Items without `run_barcode` create samples only; items with `run_barcode` also create `SampleSequencingRun` associations.
+
+**Idempotency:** If a sample already exists in the project (same `sample_id` + `project_id`), the existing row is reused rather than duplicated. Similarly, if a sample↔run association already exists, it is counted but not re-created. This makes the endpoint safe for retries and re-demux scenarios.
+
+**Response** (`200 OK`):
+
+```json
+{
+  "project_id": "PRJ-0042",
+  "samples_created": 2,
+  "samples_existing": 1,
+  "associations_created": 2,
+  "associations_existing": 0,
+  "items": [
+    {
+      "sample_id": "Sample_001",
+      "sample_uuid": "a1b2c3d4-...",
+      "project_id": "PRJ-0042",
+      "created": true,
+      "run_barcode": "240315_A00001_0001_BHXXXXXXX"
+    },
+    {
+      "sample_id": "Sample_002",
+      "sample_uuid": "e5f6g7h8-...",
+      "project_id": "PRJ-0042",
+      "created": true,
+      "run_barcode": "240315_A00001_0001_BHXXXXXXX"
+    },
+    {
+      "sample_id": "Sample_003",
+      "sample_uuid": "i9j0k1l2-...",
+      "project_id": "PRJ-0042",
+      "created": true,
+      "run_barcode": null
+    }
+  ]
+}
+```
+
+**Pre-validation errors (entire batch rejected):**
+
+| Status | Condition |
+|--------|-----------|
+| `422 Unprocessable Entity` | Duplicate `sample_id` values within the request |
+| `422 Unprocessable Entity` | Any `run_barcode` not found in the database |
+| `400 Bad Request` | Duplicate attribute keys on any single sample |
+
+### Run-Side Association Endpoints
+
 These endpoints are nested under the existing `/runs` router.
 
 ### Associate Sample with Run
@@ -180,8 +298,13 @@ This bulk endpoint is designed for the **re-demultiplexing scenario**: when a se
 
 | File | Description |
 |------|-------------|
+| `api/samples/models.py` | `Sample`, `SampleCreate` (with optional `run_barcode`), `SamplePublic`, `BulkSampleCreateRequest`, `BulkSampleItemResponse`, `BulkSampleCreateResponse` |
+| `api/samples/services.py` | `bulk_create_samples()` — atomic batch creation with idempotent resolve-or-create logic |
+| `api/project/services.py` | `add_sample_to_project()` — single-sample creation with optional run association |
+| `api/project/routes.py` | Route handlers for `POST /projects/{pid}/samples` and `POST /projects/{pid}/samples/bulk` |
 | `api/runs/models.py` | `SampleSequencingRun` table, `SampleSequencingRunCreate`, `SampleSequencingRunPublic`, and `RunSampleCleanupResponse` schemas |
 | `api/runs/services.py` | `associate_sample_with_run()`, `get_samples_for_run()`, `remove_sample_from_run()`, `clear_samples_for_run()` |
 | `api/runs/routes.py` | Route handlers under `/runs/{run_barcode}/samples` |
 | `api/search/services.py` | `delete_document_from_index()` — removes sample entries from OpenSearch on cleanup |
-| `tests/api/test_sample_run_association.py` | Association and cleanup endpoint tests (17 tests) |
+| `tests/api/test_bulk_samples.py` | Single-sample run_barcode enrichment and bulk endpoint tests (22 tests) |
+| `tests/api/test_sample_run_association.py` | Run-side association and cleanup endpoint tests (17 tests) |

--- a/tests/api/test_bulk_samples.py
+++ b/tests/api/test_bulk_samples.py
@@ -1,0 +1,624 @@
+"""Tests for single-sample run_barcode enrichment and bulk sample creation endpoint."""
+
+from datetime import date
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from api.project.models import Project
+from api.project.services import generate_project_id
+from api.runs.models import SequencingRun, SampleSequencingRun
+from api.samples.models import Sample, SampleAttribute
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_project(session: Session, name: str = "Test Project") -> str:
+    """Create a project and return its project_id."""
+    project = Project(name=name)
+    project.project_id = generate_project_id(session=session)
+    project.attributes = []
+    session.add(project)
+    session.commit()
+    session.refresh(project)
+    return project.project_id
+
+
+def _create_run(
+    session: Session,
+    *,
+    run_date: date = date(2024, 3, 15),
+    machine_id: str = "M00001",
+    run_number: int = 42,
+    flowcell_id: str = "HXXXXXXXXX",
+    experiment_name: str = "TestExp",
+) -> str:
+    """Insert a sequencing run and return its barcode."""
+    run = SequencingRun(
+        run_date=run_date,
+        machine_id=machine_id,
+        run_number=run_number,
+        flowcell_id=flowcell_id,
+        experiment_name=experiment_name,
+    )
+    session.add(run)
+    session.commit()
+    session.refresh(run)
+    return run.barcode  # e.g. "240315_M00001_0042_HXXXXXXXXX"
+
+
+def _create_second_run(session: Session) -> str:
+    """Insert a second, distinct sequencing run."""
+    return _create_run(
+        session,
+        run_date=date(2024, 4, 20),
+        machine_id="M00002",
+        run_number=99,
+        flowcell_id="JYYYYYYYYY",
+        experiment_name="TestExp2",
+    )
+
+
+# ===================================================================
+# Single-sample endpoint with run_barcode
+# ===================================================================
+
+
+class TestSingleSampleWithRunBarcode:
+    """POST /projects/{project_id}/samples with optional run_barcode."""
+
+    def test_create_sample_with_run_barcode(
+        self, client: TestClient, session: Session
+    ):
+        """Happy path: sample + SampleSequencingRun created in one call."""
+        pid = _create_project(session)
+        barcode = _create_run(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples",
+            json={
+                "sample_id": "S001",
+                "run_barcode": barcode,
+                "attributes": [{"key": "Tissue", "value": "Liver"}],
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["sample_id"] == "S001"
+        assert body["project_id"] == pid
+        assert body["run_barcode"] == barcode
+
+        # Verify the association was persisted
+        sample = session.exec(
+            select(Sample).where(Sample.sample_id == "S001", Sample.project_id == pid)
+        ).one()
+        assoc = session.exec(
+            select(SampleSequencingRun).where(
+                SampleSequencingRun.sample_id == sample.id
+            )
+        ).first()
+        assert assoc is not None
+        assert assoc.created_by == "testuser"
+
+    def test_create_sample_without_run_barcode_backward_compat(
+        self, client: TestClient, session: Session
+    ):
+        """Omitting run_barcode still works as before."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples",
+            json={"sample_id": "S002"},
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["sample_id"] == "S002"
+        assert body["run_barcode"] is None
+
+        # No association created
+        sample = session.exec(
+            select(Sample).where(Sample.sample_id == "S002", Sample.project_id == pid)
+        ).one()
+        assocs = session.exec(
+            select(SampleSequencingRun).where(
+                SampleSequencingRun.sample_id == sample.id
+            )
+        ).all()
+        assert len(assocs) == 0
+
+    def test_create_sample_with_invalid_run_barcode(
+        self, client: TestClient, session: Session
+    ):
+        """Invalid barcode returns 404; no sample is created."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples",
+            json={"sample_id": "S003", "run_barcode": "240101_XFAKE_0001_ZZZZZZZZZZ"},
+        )
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+        # Sample should NOT have been created
+        sample = session.exec(
+            select(Sample).where(Sample.sample_id == "S003", Sample.project_id == pid)
+        ).first()
+        assert sample is None
+
+    def test_create_sample_with_null_run_barcode(
+        self, client: TestClient, session: Session
+    ):
+        """Explicitly passing null run_barcode is the same as omitting it."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples",
+            json={"sample_id": "S004", "run_barcode": None},
+        )
+        assert response.status_code == 201
+        assert response.json()["run_barcode"] is None
+
+
+# ===================================================================
+# Bulk sample creation endpoint
+# ===================================================================
+
+
+class TestBulkSampleCreation:
+    """POST /projects/{project_id}/samples/bulk."""
+
+    # ----- Happy-path / basic -----
+
+    def test_bulk_create_basic(self, client: TestClient, session: Session):
+        """Create multiple samples without run associations."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "B001"},
+                    {"sample_id": "B002"},
+                    {"sample_id": "B003"},
+                ]
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["project_id"] == pid
+        assert body["samples_created"] == 3
+        assert body["samples_existing"] == 0
+        assert body["associations_created"] == 0
+        assert body["associations_existing"] == 0
+        assert len(body["items"]) == 3
+        assert all(item["created"] is True for item in body["items"])
+
+    def test_bulk_create_with_run_barcode(
+        self, client: TestClient, session: Session
+    ):
+        """All samples associated with a run in one call."""
+        pid = _create_project(session)
+        barcode = _create_run(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "R001", "run_barcode": barcode},
+                    {"sample_id": "R002", "run_barcode": barcode},
+                ]
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["samples_created"] == 2
+        assert body["associations_created"] == 2
+        for item in body["items"]:
+            assert item["run_barcode"] == barcode
+
+        # Verify associations in DB
+        for sid in ("R001", "R002"):
+            sample = session.exec(
+                select(Sample).where(
+                    Sample.sample_id == sid, Sample.project_id == pid
+                )
+            ).one()
+            assoc = session.exec(
+                select(SampleSequencingRun).where(
+                    SampleSequencingRun.sample_id == sample.id
+                )
+            ).first()
+            assert assoc is not None
+
+    def test_bulk_create_with_attributes(
+        self, client: TestClient, session: Session
+    ):
+        """Attributes are persisted for each sample in the batch."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {
+                        "sample_id": "A001",
+                        "attributes": [
+                            {"key": "Tissue", "value": "Liver"},
+                            {"key": "Condition", "value": "Healthy"},
+                        ],
+                    },
+                    {
+                        "sample_id": "A002",
+                        "attributes": [
+                            {"key": "Tissue", "value": "Heart"},
+                        ],
+                    },
+                ]
+            },
+        )
+        assert response.status_code == 201
+        assert response.json()["samples_created"] == 2
+
+        # Verify attributes persisted
+        s1 = session.exec(
+            select(Sample).where(
+                Sample.sample_id == "A001", Sample.project_id == pid
+            )
+        ).one()
+        attrs1 = session.exec(
+            select(SampleAttribute).where(SampleAttribute.sample_id == s1.id)
+        ).all()
+        assert len(attrs1) == 2
+        keys = {a.key for a in attrs1}
+        assert keys == {"Tissue", "Condition"}
+
+        s2 = session.exec(
+            select(Sample).where(
+                Sample.sample_id == "A002", Sample.project_id == pid
+            )
+        ).one()
+        attrs2 = session.exec(
+            select(SampleAttribute).where(SampleAttribute.sample_id == s2.id)
+        ).all()
+        assert len(attrs2) == 1
+        assert attrs2[0].key == "Tissue"
+        assert attrs2[0].value == "Heart"
+
+    def test_bulk_create_mixed_with_and_without_run(
+        self, client: TestClient, session: Session
+    ):
+        """Some samples have run_barcode, some don't."""
+        pid = _create_project(session)
+        barcode = _create_run(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "M001", "run_barcode": barcode},
+                    {"sample_id": "M002"},
+                    {"sample_id": "M003", "run_barcode": barcode},
+                ]
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["samples_created"] == 3
+        assert body["associations_created"] == 2
+
+        items = {i["sample_id"]: i for i in body["items"]}
+        assert items["M001"]["run_barcode"] == barcode
+        assert items["M002"]["run_barcode"] is None
+        assert items["M003"]["run_barcode"] == barcode
+
+    # ----- Idempotency -----
+
+    def test_bulk_idempotent_resubmission(
+        self, client: TestClient, session: Session
+    ):
+        """Re-submitting the same batch reuses existing samples/associations."""
+        pid = _create_project(session)
+        barcode = _create_run(session)
+
+        payload = {
+            "samples": [
+                {"sample_id": "I001", "run_barcode": barcode},
+                {"sample_id": "I002", "run_barcode": barcode},
+            ]
+        }
+
+        # First submission
+        r1 = client.post(f"/api/v1/projects/{pid}/samples/bulk", json=payload)
+        assert r1.status_code == 201
+        b1 = r1.json()
+        assert b1["samples_created"] == 2
+        assert b1["associations_created"] == 2
+
+        # Second identical submission
+        r2 = client.post(f"/api/v1/projects/{pid}/samples/bulk", json=payload)
+        assert r2.status_code == 201
+        b2 = r2.json()
+        assert b2["samples_created"] == 0
+        assert b2["samples_existing"] == 2
+        assert b2["associations_created"] == 0
+        assert b2["associations_existing"] == 2
+        assert all(item["created"] is False for item in b2["items"])
+
+        # UUIDs should match between submissions
+        uuids1 = {i["sample_id"]: i["sample_uuid"] for i in b1["items"]}
+        uuids2 = {i["sample_id"]: i["sample_uuid"] for i in b2["items"]}
+        assert uuids1 == uuids2
+
+    def test_bulk_partial_idempotency(
+        self, client: TestClient, session: Session
+    ):
+        """Batch with some existing and some new samples."""
+        pid = _create_project(session)
+
+        # Pre-create one sample
+        client.post(
+            f"/api/v1/projects/{pid}/samples",
+            json={"sample_id": "P001"},
+        )
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "P001"},  # already exists
+                    {"sample_id": "P002"},  # new
+                ]
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["samples_created"] == 1
+        assert body["samples_existing"] == 1
+
+        items = {i["sample_id"]: i for i in body["items"]}
+        assert items["P001"]["created"] is False
+        assert items["P002"]["created"] is True
+
+    # ----- Re-demux scenario -----
+
+    def test_bulk_redemux_new_run_existing_samples(
+        self, client: TestClient, session: Session
+    ):
+        """Samples already exist; new run association is added (re-demux)."""
+        pid = _create_project(session)
+        barcode1 = _create_run(session)
+        barcode2 = _create_second_run(session)
+
+        # First submission on run 1
+        r1 = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "D001", "run_barcode": barcode1},
+                    {"sample_id": "D002", "run_barcode": barcode1},
+                ]
+            },
+        )
+        assert r1.status_code == 201
+        assert r1.json()["associations_created"] == 2
+
+        # Second submission same samples, different run
+        r2 = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "D001", "run_barcode": barcode2},
+                    {"sample_id": "D002", "run_barcode": barcode2},
+                ]
+            },
+        )
+        assert r2.status_code == 201
+        b2 = r2.json()
+        assert b2["samples_created"] == 0
+        assert b2["samples_existing"] == 2
+        assert b2["associations_created"] == 2  # new run associations
+        assert b2["associations_existing"] == 0
+
+        # Each sample should now have 2 run associations
+        for sid in ("D001", "D002"):
+            sample = session.exec(
+                select(Sample).where(
+                    Sample.sample_id == sid, Sample.project_id == pid
+                )
+            ).one()
+            assocs = session.exec(
+                select(SampleSequencingRun).where(
+                    SampleSequencingRun.sample_id == sample.id
+                )
+            ).all()
+            assert len(assocs) == 2
+
+    # ----- Validation / error cases -----
+
+    def test_bulk_empty_samples_list(
+        self, client: TestClient, session: Session
+    ):
+        """Empty samples list is rejected by the validator."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={"samples": []},
+        )
+        assert response.status_code == 422
+
+    def test_bulk_duplicate_sample_ids_in_request(
+        self, client: TestClient, session: Session
+    ):
+        """Duplicate sample_ids within a single request are rejected."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "DUP1"},
+                    {"sample_id": "DUP1"},
+                ]
+            },
+        )
+        assert response.status_code == 422
+        assert "duplicate" in response.json()["detail"].lower()
+
+    def test_bulk_invalid_run_barcode(
+        self, client: TestClient, session: Session
+    ):
+        """Invalid run barcode fails the entire batch (no partial commit)."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "BAD1", "run_barcode": "240101_XFAKE_0001_ZZZZZZZZZZ"},
+                ]
+            },
+        )
+        assert response.status_code == 422
+        assert "not found" in response.json()["detail"].lower()
+
+        # No sample should have been created
+        sample = session.exec(
+            select(Sample).where(
+                Sample.sample_id == "BAD1", Sample.project_id == pid
+            )
+        ).first()
+        assert sample is None
+
+    def test_bulk_mixed_valid_and_invalid_barcode_fails_all(
+        self, client: TestClient, session: Session
+    ):
+        """One bad barcode causes the whole batch to be rejected."""
+        pid = _create_project(session)
+        good_barcode = _create_run(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "MIX1", "run_barcode": good_barcode},
+                    {"sample_id": "MIX2", "run_barcode": "240101_XFAKE_0001_ZZZZZZZZZZ"},
+                ]
+            },
+        )
+        assert response.status_code == 422
+
+        # Neither sample should have been created
+        for sid in ("MIX1", "MIX2"):
+            s = session.exec(
+                select(Sample).where(
+                    Sample.sample_id == sid, Sample.project_id == pid
+                )
+            ).first()
+            assert s is None
+
+    def test_bulk_duplicate_attribute_keys_rejected(
+        self, client: TestClient, session: Session
+    ):
+        """Duplicate attribute keys on a single sample are rejected."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {
+                        "sample_id": "ATTR1",
+                        "attributes": [
+                            {"key": "Tissue", "value": "Liver"},
+                            {"key": "Tissue", "value": "Heart"},
+                        ],
+                    },
+                ]
+            },
+        )
+        assert response.status_code == 400
+        assert "duplicate" in response.json()["detail"].lower()
+
+    def test_bulk_nonexistent_project(self, client: TestClient, session: Session):
+        """Bulk endpoint against non-existent project returns 404."""
+        response = client.post(
+            "/api/v1/projects/P-NONEXISTENT-9999/samples/bulk",
+            json={"samples": [{"sample_id": "X1"}]},
+        )
+        assert response.status_code == 404
+
+    def test_bulk_extra_field_rejected(
+        self, client: TestClient, session: Session
+    ):
+        """Extra fields in SampleCreate (model has extra='forbid') are rejected."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "E1", "unexpected_field": "boom"},
+                ]
+            },
+        )
+        assert response.status_code == 422
+
+    def test_bulk_create_created_by_is_recorded(
+        self, client: TestClient, session: Session
+    ):
+        """created_by on SampleSequencingRun reflects the authenticated user."""
+        pid = _create_project(session)
+        barcode = _create_run(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "CB1", "run_barcode": barcode},
+                ]
+            },
+        )
+        assert response.status_code == 201
+
+        sample = session.exec(
+            select(Sample).where(
+                Sample.sample_id == "CB1", Sample.project_id == pid
+            )
+        ).one()
+        assoc = session.exec(
+            select(SampleSequencingRun).where(
+                SampleSequencingRun.sample_id == sample.id
+            )
+        ).one()
+        assert assoc.created_by == "testuser"
+
+    def test_bulk_multiple_runs_in_same_batch(
+        self, client: TestClient, session: Session
+    ):
+        """Samples in one batch can reference different runs."""
+        pid = _create_project(session)
+        barcode1 = _create_run(session)
+        barcode2 = _create_second_run(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {"sample_id": "MR1", "run_barcode": barcode1},
+                    {"sample_id": "MR2", "run_barcode": barcode2},
+                    {"sample_id": "MR3"},
+                ]
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["samples_created"] == 3
+        assert body["associations_created"] == 2
+
+        items = {i["sample_id"]: i for i in body["items"]}
+        assert items["MR1"]["run_barcode"] == barcode1
+        assert items["MR2"]["run_barcode"] == barcode2
+        assert items["MR3"]["run_barcode"] is None


### PR DESCRIPTION
this PR adds the ability to associate a sample with a sequencing run at creation time, rather than requiring a second API call to do so. also - because we want a samplesheet to atomically succeed or fail, we add a bulk endpoint that validates and creates all records in a single transaction, reducing calls from 2N for N samples to 1; this is generalized and can be used for posting manifests also. tests are added for the bulk endpoint.

there is one minor bugfix - previously, for a single sample submission, if there was an error with opensearch indexing, the server could return a 500 despite having already added the sample to the database first. We now pass on exception since the relational db is the source of truth and opensearch can just be reindexed, ensuring the client correctly receives 201 Created.