### PR TITLE
Feature nwp 2117 sample files response

### DIFF
--- a/api/project/routes.py
+++ b/api/project/routes.py
@@ -2,7 +2,7 @@
 Routes/endpoints for the Project API
 """
 
-from typing import Literal
+from typing import Literal, List as TypingList
 from fastapi import APIRouter, Query, status
 from core.deps import SessionDep, OpenSearchDep, S3ClientDep
 from api.auth.deps import CurrentUser
@@ -18,6 +18,7 @@ from api.samples.models import (
     SampleCreate,
     SamplePublic,
     SamplesPublic,
+    SamplesWithFilesPublic,
     Attribute,
     BulkSampleCreateRequest,
     BulkSampleCreateResponse,
@@ -242,7 +243,9 @@ def bulk_create_samples(
 
 
 @router.get(
-    "/{project_id}/samples", tags=["Project Endpoints"], response_model=SamplesPublic
+    "/{project_id}/samples",
+    tags=["Project Endpoints"],
+    response_model=SamplesWithFilesPublic | SamplesPublic,
 )
 def get_project_samples(
     session: SessionDep,
@@ -253,9 +256,14 @@ def get_project_samples(
     sort_order: Literal["asc", "desc"] = Query(
         "asc", description="Sort order (asc or desc)"
     ),
-) -> SamplesPublic:
+    include: TypingList[str] | None = Query(
+        None, description="Include related data: files"
+    ),
+) -> SamplesWithFilesPublic | SamplesPublic:
     """
     Returns a paginated list of samples.
+
+    Pass ``?include=files`` to eagerly load file metadata for each sample.
     """
     return services.get_project_samples(
         session=session,
@@ -264,6 +272,7 @@ def get_project_samples(
         per_page=per_page,
         sort_by=sort_by,
         sort_order=sort_order,
+        include=include,
     )
 
 

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -36,6 +36,9 @@ from api.samples.models import (
     SampleCreate,
     SamplePublic,
     SamplesPublic,
+    SamplesWithFilesPublic,
+    SampleWithFilesPublic,
+    SampleFilePublic,
     Attribute,
 )
 from api.runs.models import SequencingRun, SequencingRunPublic, SampleSequencingRun
@@ -657,7 +660,8 @@ def get_project_samples(
     per_page: PositiveInt,
     sort_by: str,
     sort_order: Literal["asc", "desc"],
-) -> SamplesPublic:
+    include: list[str] | None = None,
+) -> SamplesPublic | SamplesWithFilesPublic:
     """
     Get a paginated list of samples for a specific project.
 
@@ -668,10 +672,17 @@ def get_project_samples(
         per_page: Number of items per page
         sort_by: Column name to sort by
         sort_order: Sort direction ('asc' or 'desc')
+        include: Optional list of related data to include (e.g. ``["files"]``)
 
     Returns:
-        SamplesPublic: Paginated list of samples for the project
+        SamplesPublic or SamplesWithFilesPublic depending on *include*
     """
+    from sqlalchemy.orm import selectinload
+
+    from api.files.models import FileSample, File
+
+    include_files = include is not None and "files" in include
+
     # Get the total count of samples for the project
     total_count = session.exec(
         select(func.count()).select_from(Sample).where(Sample.project_id == project.project_id)
@@ -686,6 +697,14 @@ def get_project_samples(
     # Build the select statement
     statement = select(Sample).where(Sample.project_id == project.project_id)
 
+    # Eagerly load file associations when requested
+    if include_files:
+        statement = statement.options(
+            selectinload(Sample.file_samples)  # type: ignore[attr-defined]
+            .selectinload(FileSample.file)  # type: ignore[attr-defined]
+            .selectinload(File.tags)  # type: ignore[attr-defined]
+        )
+
     # Add sorting
     if hasattr(Sample, sort_by):
         sort_column = getattr(Sample, sort_by)
@@ -699,16 +718,6 @@ def get_project_samples(
     # Execute the query
     samples = session.exec(statement).all()
 
-    # Map to public samples
-    public_samples = [
-        SamplePublic(
-            sample_id=sample.sample_id,
-            project_id=sample.project_id,
-            attributes=sample.attributes,
-        )
-        for sample in samples
-    ]
-
     # Collect all unique attribute keys across all samples for data_cols
     data_cols = None
     if samples:
@@ -719,8 +728,46 @@ def get_project_samples(
                     all_keys.add(attr.key)
         data_cols = sorted(list(all_keys)) if all_keys else None
 
+    # Build response with or without files
+    if include_files:
+        public_samples = []
+        for sample in samples:
+            files = []
+            for fs in sample.file_samples or []:
+                file = fs.file
+                tags_dict = {t.key: t.value for t in (file.tags or [])}
+                files.append(SampleFilePublic(uri=file.uri, tags=tags_dict or None))
+            public_samples.append(
+                SampleWithFilesPublic(
+                    sample_id=sample.sample_id,
+                    project_id=sample.project_id,
+                    attributes=sample.attributes,
+                    files=files if files else None,
+                )
+            )
+        return SamplesWithFilesPublic(
+            data=public_samples,
+            data_cols=data_cols,
+            total_items=total_count,
+            total_pages=total_pages,
+            current_page=page,
+            per_page=per_page,
+            has_next=page < total_pages,
+            has_prev=page > 1,
+        )
+
+    # Default: no files
+    public_samples_plain = [
+        SamplePublic(
+            sample_id=sample.sample_id,
+            project_id=sample.project_id,
+            attributes=sample.attributes,
+        )
+        for sample in samples
+    ]
+
     return SamplesPublic(
-        data=public_samples,
+        data=public_samples_plain,
         data_cols=data_cols,
         total_items=total_count,
         total_pages=total_pages,

--- a/api/samples/models.py
+++ b/api/samples/models.py
@@ -68,6 +68,34 @@ class SamplesPublic(SQLModel):
 
 
 # ---------------------------------------------------------------------------
+# Sample-with-files response models (for ?include=files)
+# ---------------------------------------------------------------------------
+
+
+class SampleFilePublic(SQLModel):
+    """Compact file representation for sample responses."""
+    uri: str
+    tags: dict[str, str] | None = None  # Flattened from List[FileTag]
+
+
+class SampleWithFilesPublic(SamplePublic):
+    """SamplePublic extended with associated files."""
+    files: List[SampleFilePublic] | None = None
+
+
+class SamplesWithFilesPublic(SQLModel):
+    """Paginated list of samples with file data included."""
+    data: List[SampleWithFilesPublic]
+    data_cols: list[str] | None = None
+    total_items: int
+    total_pages: int
+    current_page: int
+    per_page: int
+    has_next: bool
+    has_prev: bool
+
+
+# ---------------------------------------------------------------------------
 # Bulk sample creation models
 # ---------------------------------------------------------------------------
 

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 
 from api.project.models import Project
 from api.samples.models import Sample, SampleAttribute
+from api.files.models import File, FileSample, FileTag
 from api.project.services import generate_project_id
 
 
@@ -98,6 +99,10 @@ def test_get_samples_for_a_project_with_samples(client: TestClient, session: Ses
     assert response_data["data_cols"] is not None
     assert "Tissue" in response_data["data_cols"]
     assert "Condition" in response_data["data_cols"]
+
+    # Without ?include=files, samples should NOT contain a 'files' key
+    for sample in response_data["data"]:
+        assert "files" not in sample
 
     # Check that attributes are present in the response for each sample
     for sample in response_data["data"]:
@@ -319,3 +324,208 @@ def test_update_sample_attribute(client: TestClient, session: Session):
         attr["key"] == "Condition" and attr["value"] == "Diseased"
         for attr in response.json()["attributes"]
     )
+
+
+# ---------------------------------------------------------------------------
+# ?include=files tests
+# ---------------------------------------------------------------------------
+
+
+def _seed_project(session: Session) -> Project:
+    """Create a project and return it."""
+    project = Project(name="Include-Files Project")
+    project.project_id = generate_project_id(session=session)
+    project.attributes = []
+    session.add(project)
+    session.flush()
+    return project
+
+
+def _seed_sample(session: Session, project: Project, name: str) -> Sample:
+    """Create a sample in *project* and return it."""
+    sample = Sample(sample_id=name, project_id=project.project_id)
+    session.add(sample)
+    session.flush()
+    return sample
+
+
+def _attach_file(
+    session: Session,
+    sample: Sample,
+    uri: str,
+    tags: dict | None = None,
+    role: str | None = None,
+) -> File:
+    """Create a File, link it to *sample* via FileSample, optionally add tags."""
+    file = File(uri=uri)
+    session.add(file)
+    session.flush()
+
+    fs = FileSample(file_id=file.id, sample_id=sample.id, role=role)
+    session.add(fs)
+
+    if tags:
+        for key, value in tags.items():
+            session.add(FileTag(file_id=file.id, key=key, value=value))
+
+    session.flush()
+    return file
+
+
+def test_get_samples_include_files_with_tagged_files(
+    client: TestClient, session: Session
+):
+    """With ?include=files, samples that have files should return them with
+    flat-dict tags."""
+    project = _seed_project(session)
+    sample = _seed_sample(session, project, "SampleWithFastqs")
+
+    _attach_file(
+        session, sample,
+        uri="s3://bucket/P-1234/SampleWithFastqs_1.fastq.gz",
+        tags={"mate": "R1"},
+    )
+    _attach_file(
+        session, sample,
+        uri="s3://bucket/P-1234/SampleWithFastqs_2.fastq.gz",
+        tags={"mate": "R2"},
+    )
+    session.commit()
+
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"include": "files"},
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total_items"] == 1
+
+    sample_item = data["data"][0]
+    assert sample_item["sample_id"] == "SampleWithFastqs"
+    assert sample_item["files"] is not None
+    assert len(sample_item["files"]) == 2
+
+    # Tags should be a flat dict, NOT a list of {key, value}
+    uris = {f["uri"] for f in sample_item["files"]}
+    assert "s3://bucket/P-1234/SampleWithFastqs_1.fastq.gz" in uris
+    assert "s3://bucket/P-1234/SampleWithFastqs_2.fastq.gz" in uris
+
+    for file_obj in sample_item["files"]:
+        assert isinstance(file_obj["tags"], dict)
+        assert "mate" in file_obj["tags"]
+        assert file_obj["tags"]["mate"] in ("R1", "R2")
+
+
+def test_get_samples_include_files_sample_with_no_files(
+    client: TestClient, session: Session
+):
+    """A sample with no associated files should return ``files: null``."""
+    project = _seed_project(session)
+    _seed_sample(session, project, "LonelySample")
+    session.commit()
+
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"include": "files"},
+    )
+    assert response.status_code == 200
+
+    sample_item = response.json()["data"][0]
+    assert sample_item["files"] is None
+
+
+def test_get_samples_include_files_with_untagged_files(
+    client: TestClient, session: Session
+):
+    """A file with no tags should still appear; tags should be null."""
+    project = _seed_project(session)
+    sample = _seed_sample(session, project, "SampleNoTags")
+    _attach_file(session, sample, uri="s3://bucket/P-1234/SampleNoTags.bam")
+    session.commit()
+
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"include": "files"},
+    )
+    assert response.status_code == 200
+
+    sample_item = response.json()["data"][0]
+    assert sample_item["files"] is not None
+    assert len(sample_item["files"]) == 1
+    assert sample_item["files"][0]["uri"] == "s3://bucket/P-1234/SampleNoTags.bam"
+    # No tags → null (empty dict converted to None in model)
+    assert sample_item["files"][0]["tags"] is None
+
+
+def test_get_samples_include_files_pagination_works(
+    client: TestClient, session: Session
+):
+    """Pagination should still work correctly when include=files."""
+    project = _seed_project(session)
+    for i in range(5):
+        s = _seed_sample(session, project, f"PaginatedSample_{i:02d}")
+        _attach_file(
+            session, s,
+            uri=f"s3://bucket/P-1234/PaginatedSample_{i:02d}.bam",
+            tags={"index": str(i)},
+        )
+    session.commit()
+
+    # Page 1, per_page=2
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"include": "files", "per_page": 2, "page": 1},
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total_items"] == 5
+    assert data["per_page"] == 2
+    assert data["current_page"] == 1
+    assert data["has_next"] is True
+    assert len(data["data"]) == 2
+
+    # Every sample on the page should have files
+    for sample_item in data["data"]:
+        assert sample_item["files"] is not None
+        assert len(sample_item["files"]) == 1
+
+    # Page 3 (last), per_page=2 → 1 sample
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"include": "files", "per_page": 2, "page": 3},
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["data"]) == 1
+    assert data["has_next"] is False
+    assert data["has_prev"] is True
+
+
+def test_get_samples_include_files_mixed_samples(
+    client: TestClient, session: Session
+):
+    """A project with a mix of samples (with and without files) returns the
+    correct shape for each."""
+    project = _seed_project(session)
+
+    # Sample with files
+    s1 = _seed_sample(session, project, "SampleWithFiles")
+    _attach_file(session, s1, uri="s3://bucket/file1.fastq.gz", tags={"mate": "R1"})
+
+    # Sample without files
+    _seed_sample(session, project, "SampleWithNoFiles")
+    session.commit()
+
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"include": "files"},
+    )
+    assert response.status_code == 200
+
+    items = {s["sample_id"]: s for s in response.json()["data"]}
+    assert items["SampleWithFiles"]["files"] is not None
+    assert len(items["SampleWithFiles"]["files"]) == 1
+    assert items["SampleWithNoFiles"]["files"] is None


### PR DESCRIPTION
the backend worker needs files for each sample to construct samplesheets. however, the GET samples endpoint only returned attributes, not associated files.

this PR modifies the route to include an optional ?includes=files querystring param which keeps the existing return format by default, but optionally returns a new public model with the full files + tags included to enable samplesheet generation.