### PR TITLE
Feature presign downloads

### DIFF
--- a/api/files/routes.py
+++ b/api/files/routes.py
@@ -10,13 +10,12 @@ Endpoints:
 - GET /api/files/download - Download file from S3
 """
 
-import io
 from typing import Optional
 import uuid
 
 from fastapi import APIRouter, Depends, Query, status, Form, UploadFile
 from fastapi import File as FastAPIFile
-from fastapi.responses import StreamingResponse
+from fastapi.responses import RedirectResponse
 
 from api.files.models import FileUploadCreate
 
@@ -235,6 +234,7 @@ def browse_s3(
 @router.get(
     "/download",
     summary="Download file from S3",
+    responses={307: {"description": "Redirect to presigned S3 URL"}},
 )
 def download_file(
     path: str = Query(
@@ -242,24 +242,18 @@ def download_file(
         description="S3 URI of file to download (e.g., s3://bucket/path/file.txt)"
     ),
     s3_client=Depends(get_s3_client),
-) -> StreamingResponse:
+):
     """
-    Download a file from S3.
+    Download a file from S3 via presigned URL redirect.
 
-    Returns the file as a streaming download with appropriate
-    content type and filename.
+    Returns a 307 redirect to a time-limited presigned S3 URL.
+    The client follows the redirect to download directly from S3,
+    offloading bandwidth from the API server.
     """
-    file_content, content_type, filename = services.download_file(
+    presigned_url = services.generate_presigned_url(
         s3_path=path, s3_client=s3_client
     )
-
-    return StreamingResponse(
-        io.BytesIO(file_content),
-        media_type=content_type,
-        headers={
-            "Content-Disposition": f'attachment; filename="{filename}"'
-        }
-    )
+    return RedirectResponse(url=presigned_url, status_code=307)
 
 
 @router.get(

--- a/api/files/services.py
+++ b/api/files/services.py
@@ -940,6 +940,83 @@ def download_file(s3_path: str, s3_client=None) -> tuple[bytes, str, str]:
         ) from exc
 
 
+def generate_presigned_url(
+    s3_path: str,
+    s3_client=None,
+    expiration: int = 3600,
+) -> str:
+    """
+    Generate a presigned URL for downloading a file from S3.
+
+    Args:
+        s3_path: The S3 URI of the file (e.g., s3://bucket/path/file.txt)
+        s3_client: Optional boto3 S3 client
+        expiration: URL expiration time in seconds (default: 1 hour)
+
+    Returns:
+        Presigned URL string
+
+    Raises:
+        HTTPException: If S3 path is invalid or credentials unavailable
+    """
+    if not BOTO3_AVAILABLE:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="S3 support not available. Install boto3.",
+        )
+
+    try:
+        bucket, key = _parse_s3_path(s3_path)
+
+        if not key:
+            raise ValueError(
+                "S3 path must include a file key, not just a bucket"
+            )
+
+        if s3_client is None:
+            s3_client = boto3.client("s3")
+
+        presigned_url = s3_client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=expiration,
+        )
+        return presigned_url
+
+    except NoCredentialsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="AWS credentials not found.",
+        ) from exc
+    except ClientError as exc:
+        error_code = exc.response["Error"]["Code"]
+        if error_code == "NoSuchKey":
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"File not found: {s3_path}",
+            ) from exc
+        elif error_code == "NoSuchBucket":
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="S3 bucket not found",
+            ) from exc
+        elif error_code == "AccessDenied":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Access denied: {s3_path}",
+            ) from exc
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"S3 error: {exc.response['Error']['Message']}",
+            ) from exc
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+
 def list_s3_files(uri: str, s3_client=None) -> FileBrowserData:
     """
     List files and folders at the specified S3 URI.

--- a/tests/api/test_presigned_download.py
+++ b/tests/api/test_presigned_download.py
@@ -1,0 +1,193 @@
+"""Tests for presigned URL download endpoint and service."""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from api.files.services import generate_presigned_url
+from tests.conftest import MockS3Client
+
+
+class TestGeneratePresignedUrlService:
+    """Unit tests for generate_presigned_url service function."""
+
+    def test_generate_presigned_url_success(self, mock_s3_client: MockS3Client):
+        """Test successful presigned URL generation."""
+        url = generate_presigned_url(
+            s3_path="s3://test-bucket/path/to/file.txt",
+            s3_client=mock_s3_client,
+        )
+        assert "test-bucket.s3.amazonaws.com" in url
+        assert "path/to/file.txt" in url
+        assert "X-Amz-Signature" in url
+
+    def test_generate_presigned_url_custom_expiration(
+        self, mock_s3_client: MockS3Client
+    ):
+        """Test presigned URL with custom expiration."""
+        url = generate_presigned_url(
+            s3_path="s3://test-bucket/file.bam",
+            s3_client=mock_s3_client,
+            expiration=7200,
+        )
+        assert "X-Amz-Expires=7200" in url
+
+    def test_generate_presigned_url_default_expiration(
+        self, mock_s3_client: MockS3Client
+    ):
+        """Test presigned URL uses default 1-hour expiration."""
+        url = generate_presigned_url(
+            s3_path="s3://test-bucket/file.bam",
+            s3_client=mock_s3_client,
+        )
+        assert "X-Amz-Expires=3600" in url
+
+    def test_generate_presigned_url_invalid_path(
+        self, mock_s3_client: MockS3Client
+    ):
+        """Test error on invalid S3 path."""
+        with pytest.raises(HTTPException) as exc_info:
+            generate_presigned_url(
+                s3_path="not-an-s3-path",
+                s3_client=mock_s3_client,
+            )
+        assert exc_info.value.status_code == 400
+
+    def test_generate_presigned_url_bucket_only(
+        self, mock_s3_client: MockS3Client
+    ):
+        """Test error when path has no file key."""
+        with pytest.raises(HTTPException) as exc_info:
+            generate_presigned_url(
+                s3_path="s3://bucket-only",
+                s3_client=mock_s3_client,
+            )
+        assert exc_info.value.status_code == 400
+        assert "file key" in exc_info.value.detail.lower()
+
+    def test_generate_presigned_url_no_credentials(
+        self, mock_s3_client: MockS3Client
+    ):
+        """Test error when AWS credentials are missing."""
+        mock_s3_client.simulate_error("NoCredentialsError")
+        with pytest.raises(HTTPException) as exc_info:
+            generate_presigned_url(
+                s3_path="s3://test-bucket/file.txt",
+                s3_client=mock_s3_client,
+            )
+        assert exc_info.value.status_code == 401
+
+    def test_generate_presigned_url_bucket_not_found(
+        self, mock_s3_client: MockS3Client
+    ):
+        """Test error when S3 bucket doesn't exist."""
+        mock_s3_client.simulate_error("NoSuchBucket")
+        with pytest.raises(HTTPException) as exc_info:
+            generate_presigned_url(
+                s3_path="s3://nonexistent/file.txt",
+                s3_client=mock_s3_client,
+            )
+        assert exc_info.value.status_code == 404
+
+    def test_generate_presigned_url_access_denied(
+        self, mock_s3_client: MockS3Client
+    ):
+        """Test error when access is denied."""
+        mock_s3_client.simulate_error("AccessDenied")
+        with pytest.raises(HTTPException) as exc_info:
+            generate_presigned_url(
+                s3_path="s3://restricted-bucket/secret.txt",
+                s3_client=mock_s3_client,
+            )
+        assert exc_info.value.status_code == 403
+
+
+class TestDownloadFileRoute:
+    """Integration tests for GET /api/v1/files/download endpoint."""
+
+    def test_download_returns_307_redirect(
+        self, client: TestClient, mock_s3_client: MockS3Client
+    ):
+        """Test that download endpoint returns 307 redirect."""
+        response = client.get(
+            "/api/v1/files/download",
+            params={"path": "s3://test-bucket/data/sample.fastq.gz"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 307
+        location = response.headers["location"]
+        assert "test-bucket.s3.amazonaws.com" in location
+        assert "data/sample.fastq.gz" in location
+        assert "X-Amz-Signature" in location
+
+    def test_download_redirect_location_header(
+        self, client: TestClient, mock_s3_client: MockS3Client
+    ):
+        """Test that the Location header contains a valid presigned URL."""
+        response = client.get(
+            "/api/v1/files/download",
+            params={"path": "s3://my-bucket/path/to/report.html"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 307
+        location = response.headers["location"]
+        assert location.startswith("https://")
+        assert "X-Amz-Expires" in location
+
+    def test_download_missing_path_param(self, client: TestClient):
+        """Test 422 error when path query param is missing."""
+        response = client.get("/api/v1/files/download")
+        assert response.status_code == 422
+
+    def test_download_invalid_s3_path(
+        self, client: TestClient, mock_s3_client: MockS3Client
+    ):
+        """Test 400 error for invalid S3 path."""
+        response = client.get(
+            "/api/v1/files/download",
+            params={"path": "/local/path/file.txt"},
+        )
+        assert response.status_code == 400
+
+    def test_download_no_credentials(
+        self, client: TestClient, mock_s3_client: MockS3Client
+    ):
+        """Test 401 when AWS credentials are missing."""
+        mock_s3_client.simulate_error("NoCredentialsError")
+        response = client.get(
+            "/api/v1/files/download",
+            params={"path": "s3://test-bucket/file.txt"},
+        )
+        assert response.status_code == 401
+
+    def test_download_access_denied(
+        self, client: TestClient, mock_s3_client: MockS3Client
+    ):
+        """Test 403 when S3 access is denied."""
+        mock_s3_client.simulate_error("AccessDenied")
+        response = client.get(
+            "/api/v1/files/download",
+            params={"path": "s3://restricted-bucket/file.txt"},
+        )
+        assert response.status_code == 403
+
+    def test_download_bucket_not_found(
+        self, client: TestClient, mock_s3_client: MockS3Client
+    ):
+        """Test 404 when S3 bucket doesn't exist."""
+        mock_s3_client.simulate_error("NoSuchBucket")
+        response = client.get(
+            "/api/v1/files/download",
+            params={"path": "s3://nonexistent-bucket/file.txt"},
+        )
+        assert response.status_code == 404
+
+    def test_download_bucket_only_no_key(
+        self, client: TestClient, mock_s3_client: MockS3Client
+    ):
+        """Test 400 when S3 path has bucket but no file key."""
+        response = client.get(
+            "/api/v1/files/download",
+            params={"path": "s3://test-bucket"},
+        )
+        assert response.status_code == 400

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,37 @@ class MockS3Client:
 
         return {"ETag": '"mock-etag"', "VersionId": "mock-version-id"}
 
+    def generate_presigned_url(
+        self, ClientMethod: str, Params: dict = None, ExpiresIn: int = 3600
+    ):
+        """Mock S3 generate_presigned_url operation"""
+        from botocore.exceptions import NoCredentialsError, ClientError
+
+        # Check for simulated errors
+        if self.error_mode == "NoCredentialsError":
+            raise NoCredentialsError()
+        elif self.error_mode == "NoSuchBucket":
+            error_response = {
+                "Error": {
+                    "Code": "NoSuchBucket",
+                    "Message": "The specified bucket does not exist",
+                }
+            }
+            raise ClientError(error_response, "GeneratePresignedUrl")
+        elif self.error_mode == "AccessDenied":
+            error_response = {
+                "Error": {"Code": "AccessDenied", "Message": "Access Denied"}
+            }
+            raise ClientError(error_response, "GeneratePresignedUrl")
+
+        Params = Params or {}
+        bucket = Params.get("Bucket", "mock-bucket")
+        key = Params.get("Key", "mock-key")
+        return (
+            f"https://{bucket}.s3.amazonaws.com/{key}"
+            f"?X-Amz-Expires={ExpiresIn}&X-Amz-Signature=mock-signature"
+        )
+
     def head_object(self, Bucket: str, Key: str, **kwargs):
         """Mock S3 head_object operation - check if object exists"""
         from botocore.exceptions import NoCredentialsError, ClientError


### PR DESCRIPTION
Currently - file download streams a file to the requesting client directly; for large genomic files like BAMs, though, this can put severe load on the APIServer. Here, we return a redirect to a presigned URL to the client, offloading file transfer bandwidth/overhead from the API server directly to S3.

There is only one consumer of `/api/v1/files/download` in the frontend:
**[`file-browser.tsx`](../frontend-ui/src/components/file-browser.tsx:143)** — the `handleFileDownload` handler. Browsers natively follow 301/302/307 redirects, so the user will seamlessly land on the presigned S3 URL.

Note that we're returning 307 instead 301 - since 301 ("Permanent Redirect") are cacheable, the download can become stale or stop working after the lifetime of the presigned URL. Both the frontend and any client following a redirect will treat these codes equivalently.