### PR TITLE
Feature validator post manifest

### DIFF
--- a/api/manifest/models.py
+++ b/api/manifest/models.py
@@ -1,6 +1,8 @@
 """
 Models for the Manifest API
 """
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -28,4 +30,12 @@ class ManifestValidationResponse(BaseModel):
     warning: dict[str, list[str]] = Field(
         default_factory=dict,
         description="Validation warnings grouped by category"
+    )
+    post_results: Optional[dict] = Field(
+        default=None,
+        description="Results from posting samples to API after successful validation"
+    )
+    post_error: Optional[str] = Field(
+        default=None,
+        description="Error message if posting samples failed"
     )

--- a/api/manifest/routes.py
+++ b/api/manifest/routes.py
@@ -89,6 +89,9 @@ def validate_manifest(
         None, description="(S3, GS) path where files described in manifest are located "
                           "(e.g. s3://vendorbucket/path/to/files/)"
     ),
+    post_to_api: Optional[bool] = Query(
+        False, description="If true, post samples to API after successful validation"
+    ),
 ) -> ManifestValidationResponse:
     """
     Validate a manifest CSV file from S3 using the ngs360-manifest-validator Lambda.
@@ -116,5 +119,6 @@ def validate_manifest(
         manifest_uri=manifest_uri,
         files_uri=files_uri,
         manifest_version=manifest_version,
+        post_to_api=post_to_api,
     )
     return result

--- a/api/manifest/services.py
+++ b/api/manifest/services.py
@@ -225,7 +225,8 @@ def validate_manifest_file(
     session: SessionDep,
     manifest_uri: str,
     files_uri: str,
-    manifest_version: Optional[str] = None
+    manifest_version: Optional[str] = None,
+    post_to_api: bool = False
 ) -> ManifestValidationResponse:
     """
     Validate a manifest CSV file from S3 by invoking a Lambda function.
@@ -269,6 +270,8 @@ def validate_manifest_file(
         # Add optional parameters if provided
         if manifest_version:
             payload["manifest_version"] = manifest_version
+        if post_to_api:
+            payload["post_to_api"] = True
 
         # Invoke Lambda function synchronously
         response = lambda_client.invoke(
@@ -341,7 +344,9 @@ def validate_manifest_file(
             valid=validation_result.get("validation_passed", False),
             message=validation_result.get("messages", {}),
             error=validation_result.get("errors", {}),
-            warning=validation_result.get("warnings", {})
+            warning=validation_result.get("warnings", {}),
+            post_results=validation_result.get("post_results"),
+            post_error=validation_result.get("post_error"),
         )
 
     except NoCredentialsError as exc:

--- a/tests/api/test_manifest.py
+++ b/tests/api/test_manifest.py
@@ -754,7 +754,17 @@ class TestManifestValidation:
 
         # Both should have the same keys
         assert set(valid_data.keys()) == set(invalid_data.keys())
-        assert set(valid_data.keys()) == {"valid", "message", "error", "warning"}
+        expected_keys = {
+            "valid", "message", "error", "warning",
+            "post_results", "post_error",
+        }
+        assert set(valid_data.keys()) == expected_keys
+
+        # New fields should be None by default (post_to_api was not passed)
+        assert valid_data["post_results"] is None
+        assert valid_data["post_error"] is None
+        assert invalid_data["post_results"] is None
+        assert invalid_data["post_error"] is None
 
         # Both should have dict types for message, error, warning
         for data in [valid_data, invalid_data]:
@@ -849,17 +859,26 @@ class TestManifestValidation:
         # Verify manifest_version was passed (uppercased) to Lambda
         last_payload = mock_lambda_client.invocations[-1]["Payload"]
         assert last_payload["manifest_version"] == "DTS12.1"
+        # default=False means key omitted from Lambda payload
+        assert "post_to_api" not in last_payload
 
-    def test_validate_manifest_with_files_bucket_and_prefix(
+    def test_validate_manifest_with_files_uri_and_post_to_api(
         self, client: TestClient, mock_lambda_client
     ):
-        """Test validation endpoint with files_bucket and files_prefix parameters"""
+        """Test validation endpoint with files_uri and post_to_api=true.
+
+        Verifies:
+        - files_uri is forwarded to Lambda payload
+        - post_to_api=true is forwarded to Lambda payload
+        - post_results from Lambda response is passed through to the API response
+        """
         mock_lambda_client.set_response({
             "success": True,
             "validation_passed": True,
             "messages": {},
             "errors": {},
             "warnings": {},
+            "post_results": {"samples_created": 5, "project": "P-00000000-0001"},
             "statusCode": 200
         })
 
@@ -867,13 +886,22 @@ class TestManifestValidation:
             "/api/v1/manifest/validate"
             "?manifest_uri=s3://test-bucket/manifest.csv"
             "&files_uri=s3://data-bucket/raw/fastq/"
+            "&post_to_api=true"
         )
 
         assert response.status_code == 200
 
-        # Verify files_bucket and files_prefix were passed to Lambda
+        # Verify files_uri was passed to Lambda
         last_payload = mock_lambda_client.invocations[-1]["Payload"]
         assert last_payload["files_uri"] == "s3://data-bucket/raw/fastq/"
+
+        # Verify post_to_api was forwarded to Lambda
+        assert last_payload["post_to_api"] is True
+
+        # Verify post_results passed through in response
+        data = response.json()
+        assert data["post_results"] == {"samples_created": 5, "project": "P-00000000-0001"}
+        assert data["post_error"] is None
 
     def test_validate_manifest_files_bucket_defaults_to_s3_path_bucket(
         self, client: TestClient, mock_lambda_client


### PR DESCRIPTION
Add optional post_to_api query parameter to POST /api/v1/manifest/validate that forwards to the Lambda function. When true, the Lambda posts parsed samples to the bulk sample creation endpoint after successful validation.

This is needed by the copyVendorToData batch job.