### PR TITLE
Add PATCH /projects/{project_id} endpoint so workers can non-destructively add attributes

### DIFF
--- a/api/project/routes.py
+++ b/api/project/routes.py
@@ -162,9 +162,41 @@ def update_project(
     update_request: ProjectUpdate
 ) -> ProjectPublic:
     """
-    Update information about a specific project.
+    Full replacement update of a project.
+
+    Attributes provided here **replace** all existing attributes.
+    To merge/upsert attributes without removing unmentioned ones,
+    use ``PATCH /{project_id}`` instead.
     """
     return services.update_project(
+        session=session,
+        opensearch_client=opensearch_client,
+        project_id=project.project_id,
+        update_request=update_request,
+    )
+
+
+@router.patch(
+    "/{project_id}",
+    status_code=status.HTTP_200_OK,
+    tags=["Project Endpoints"],
+    response_model=ProjectPublic,
+)
+def patch_project(
+    session: SessionDep,
+    opensearch_client: OpenSearchDep,
+    project: ProjectDep,
+    update_request: ProjectUpdate,
+) -> ProjectPublic:
+    """
+    Partially update a project using merge/upsert semantics.
+
+    Unlike PUT, this does **not** remove attributes that are absent
+    from the request.  Each supplied attribute is upserted: existing
+    keys are updated, new keys are inserted, and unmentioned keys
+    are left untouched.  An empty attributes list is a no-op.
+    """
+    return services.patch_project(
         session=session,
         opensearch_client=opensearch_client,
         project_id=project.project_id,

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -318,6 +318,101 @@ def update_project(
     )
 
 
+def patch_project(
+    *,
+    session: Session,
+    opensearch_client: OpenSearch,
+    project_id: str,
+    update_request: ProjectUpdate,
+) -> ProjectPublic:
+    """
+    Partially update a project using merge/upsert semantics.
+
+    Unlike ``update_project`` (PUT), this does **not** remove attributes
+    that are absent from the request.  Each supplied attribute is upserted:
+    existing keys have their value updated, new keys are inserted, and
+    unmentioned keys are left untouched.  An empty attributes list is a
+    no-op.
+    """
+    # Fetch the project
+    project = session.exec(
+        select(Project).where(Project.project_id == project_id)
+    ).first()
+
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Project {project_id} not found.",
+        )
+
+    # Update name if provided
+    if update_request.name is not None:
+        project.name = update_request.name
+
+    # Merge/upsert attributes (does NOT remove unmentioned attributes)
+    if (
+        update_request.attributes is not None
+        and len(update_request.attributes) > 0
+    ):
+        # Prevent duplicate keys in the request
+        seen = set()
+        keys = [attr.key for attr in update_request.attributes]
+        dups = [k for k in keys if k in seen or seen.add(k)]
+        if dups:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Duplicate keys ({', '.join(dups)}) are not "
+                    f"allowed in project attributes."
+                ),
+            )
+
+        for attr in update_request.attributes:
+            existing_attr = session.exec(
+                select(ProjectAttribute).where(
+                    ProjectAttribute.project_id == project.id,
+                    ProjectAttribute.key == attr.key,
+                )
+            ).first()
+
+            if existing_attr:
+                existing_attr.value = attr.value
+            else:
+                session.add(
+                    ProjectAttribute(
+                        project_id=project.id,
+                        key=attr.key,
+                        value=attr.value,
+                    )
+                )
+
+    session.commit()
+    session.refresh(project)
+
+    # Update project in opensearch
+    if opensearch_client:
+        search_doc = SearchDocument(
+            id=project.project_id, body=project
+        )
+        add_object_to_index(
+            opensearch_client, search_doc, index="projects"
+        )
+
+    data_bucket = get_setting_value(session, "DATA_BUCKET_URI")
+    results_bucket = get_setting_value(session, "RESULTS_BUCKET_URI")
+
+    return ProjectPublic(
+        project_id=project.project_id,
+        name=project.name,
+        data_folder_uri=f"{data_bucket}/{project.project_id}/",
+        results_folder_uri=(
+            f"{results_bucket}/{project.project_id}/"
+        ),
+        attributes=project.attributes,
+        sequencing_runs=None,
+    )
+
+
 def search_projects(
     session: Session,
     client: OpenSearch,

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -512,6 +512,176 @@ def test_update_project_removes_all_attributes(client: TestClient, session: Sess
 
 
 ###############################################################################
+# PATCH Project Tests (merge/upsert semantics)
+###############################################################################
+
+
+def test_patch_project_merge_preserves_existing(
+    client: TestClient, session: Session
+):
+    """Test that PATCH with a new attribute preserves all existing attributes"""
+    new_project = Project(name="Test Project")
+    new_project.project_id = generate_project_id(session=session)
+    new_project.attributes = [
+        ProjectAttribute(key="project_type", value="RNA-Seq"),
+        ProjectAttribute(key="pi", value="Dr. Smith"),
+    ]
+    session.add(new_project)
+    session.commit()
+
+    # Add a single new attribute (simulates NGS-BMS worker)
+    update_data = {
+        "attributes": [
+            {"key": "xpress_project_id", "value": "-1"},
+        ]
+    }
+    response = client.patch(
+        f"/api/v1/projects/{new_project.project_id}",
+        json=update_data,
+    )
+
+    assert response.status_code == 200
+    response_json = response.json()
+
+    # All three attributes should be present
+    assert len(response_json["attributes"]) == 3
+    attr_dict = {
+        a["key"]: a["value"] for a in response_json["attributes"]
+    }
+    assert attr_dict["project_type"] == "RNA-Seq"
+    assert attr_dict["pi"] == "Dr. Smith"
+    assert attr_dict["xpress_project_id"] == "-1"
+
+
+def test_patch_project_upsert_existing_key(
+    client: TestClient, session: Session
+):
+    """Test that PATCH with an existing key updates only that value"""
+    new_project = Project(name="Test Project")
+    new_project.project_id = generate_project_id(session=session)
+    new_project.attributes = [
+        ProjectAttribute(key="project_type", value="RNA-Seq"),
+        ProjectAttribute(key="xpress_project_id", value="-1"),
+        ProjectAttribute(key="pi", value="Dr. Smith"),
+    ]
+    session.add(new_project)
+    session.commit()
+
+    update_data = {
+        "attributes": [
+            {"key": "xpress_project_id", "value": "12345"},
+        ]
+    }
+    response = client.patch(
+        f"/api/v1/projects/{new_project.project_id}",
+        json=update_data,
+    )
+
+    assert response.status_code == 200
+    response_json = response.json()
+
+    assert len(response_json["attributes"]) == 3
+    attr_dict = {
+        a["key"]: a["value"] for a in response_json["attributes"]
+    }
+    assert attr_dict["project_type"] == "RNA-Seq"
+    assert attr_dict["pi"] == "Dr. Smith"
+    assert attr_dict["xpress_project_id"] == "12345"
+
+
+def test_patch_project_empty_attributes_is_noop(
+    client: TestClient, session: Session
+):
+    """Test that PATCH with empty attributes list is a no-op"""
+    new_project = Project(name="Test Project")
+    new_project.project_id = generate_project_id(session=session)
+    new_project.attributes = [
+        ProjectAttribute(key="Department", value="R&D"),
+        ProjectAttribute(key="Priority", value="High"),
+    ]
+    session.add(new_project)
+    session.commit()
+
+    update_data = {"attributes": []}
+    response = client.patch(
+        f"/api/v1/projects/{new_project.project_id}",
+        json=update_data,
+    )
+
+    assert response.status_code == 200
+    response_json = response.json()
+
+    assert len(response_json["attributes"]) == 2
+    attr_dict = {
+        a["key"]: a["value"] for a in response_json["attributes"]
+    }
+    assert attr_dict["Department"] == "R&D"
+    assert attr_dict["Priority"] == "High"
+
+
+def test_patch_project_name_only(
+    client: TestClient, session: Session
+):
+    """Test that PATCH can update name without touching attributes"""
+    new_project = Project(name="Original Name")
+    new_project.project_id = generate_project_id(session=session)
+    new_project.attributes = [
+        ProjectAttribute(key="Department", value="R&D"),
+    ]
+    session.add(new_project)
+    session.commit()
+
+    update_data = {"name": "Updated Name"}
+    response = client.patch(
+        f"/api/v1/projects/{new_project.project_id}",
+        json=update_data,
+    )
+
+    assert response.status_code == 200
+    response_json = response.json()
+    assert response_json["name"] == "Updated Name"
+    assert len(response_json["attributes"]) == 1
+    assert response_json["attributes"][0]["key"] == "Department"
+    assert response_json["attributes"][0]["value"] == "R&D"
+
+
+def test_patch_project_not_found(client: TestClient):
+    """Test that PATCH on a non-existent project returns 404"""
+    update_data = {"name": "New Name"}
+    response = client.patch(
+        "/api/v1/projects/nonexistent-project-id",
+        json=update_data,
+    )
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_patch_project_duplicate_attribute_keys(
+    client: TestClient, session: Session
+):
+    """Test that PATCH with duplicate attribute keys fails"""
+    new_project = Project(name="Test Project")
+    new_project.project_id = generate_project_id(session=session)
+    new_project.attributes = []
+    session.add(new_project)
+    session.commit()
+
+    update_data = {
+        "attributes": [
+            {"key": "Priority", "value": "High"},
+            {"key": "Priority", "value": "Low"},
+        ]
+    }
+    response = client.patch(
+        f"/api/v1/projects/{new_project.project_id}",
+        json=update_data,
+    )
+
+    assert response.status_code == 400
+    assert "duplicate" in response.json()["detail"].lower()
+
+
+###############################################################################
 # Pipeline Job Submission Tests
 ###############################################################################
 


### PR DESCRIPTION
This PR adds a PATCH project endpoint so that client workers can add project attributes non-destructively such as a link to an external database where expression data was loaded after project export.

We need to leave PUT untouched so the frontend-ui can intentionally remove attributes.