### PR TITLE
Invoke manifest validator lambda by alias, not $LATEST

### DIFF
--- a/api/manifest/services.py
+++ b/api/manifest/services.py
@@ -245,9 +245,15 @@ def validate_manifest_file(
         get_setting_value(session, "MANIFEST_VALIDATION_LAMBDA")
         or "ngs360-manifest-validator"
     )
+    # Get Lambda qualifier (alias/version) from settings, fall back to "main"
+    lambda_qualifier = (
+        get_setting_value(session, "MANIFEST_VALIDATION_LAMBDA_QUALIFIER")
+        or "main"
+    )
     logger.info(
-        "Invoking Lambda function: %s for manifest validation of %s",
+        "Invoking Lambda function: %s (qualifier: %s) for manifest validation of %s",
         lambda_function_name,
+        lambda_qualifier,
         manifest_uri
     )
 
@@ -273,11 +279,11 @@ def validate_manifest_file(
         if post_to_api:
             payload["post_to_api"] = True
 
-        # Invoke Lambda function synchronously using the "main" alias
+        # Invoke Lambda function synchronously using the configured alias
         response = lambda_client.invoke(
             FunctionName=lambda_function_name,
             InvocationType="RequestResponse",
-            Qualifier="main",
+            Qualifier=lambda_qualifier,
             Payload=json.dumps(payload)
         )
 

--- a/api/manifest/services.py
+++ b/api/manifest/services.py
@@ -273,10 +273,11 @@ def validate_manifest_file(
         if post_to_api:
             payload["post_to_api"] = True
 
-        # Invoke Lambda function synchronously
+        # Invoke Lambda function synchronously using the "main" alias
         response = lambda_client.invoke(
             FunctionName=lambda_function_name,
             InvocationType="RequestResponse",
+            Qualifier="main",
             Payload=json.dumps(payload)
         )
 

--- a/tests/api/test_manifest.py
+++ b/tests/api/test_manifest.py
@@ -9,6 +9,7 @@ import pytest
 
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from sqlmodel import Session
 
 from api.manifest.services import get_latest_manifest_file
 
@@ -902,6 +903,72 @@ class TestManifestValidation:
         data = response.json()
         assert data["post_results"] == {"samples_created": 5, "project": "P-00000000-0001"}
         assert data["post_error"] is None
+
+    def test_validate_manifest_uses_qualifier_from_settings(
+        self, client: TestClient, mock_lambda_client, session: Session
+    ):
+        """Test that Lambda qualifier is read from MANIFEST_VALIDATION_LAMBDA_QUALIFIER setting.
+
+        Uses a non-default value ('staging') to prove the qualifier comes from
+        the DB setting rather than the hardcoded fallback.
+        """
+        from api.settings.models import Setting
+        from sqlmodel import select
+
+        # Update the qualifier setting to a non-default value
+        setting = session.exec(
+            select(Setting).where(Setting.key == "MANIFEST_VALIDATION_LAMBDA_QUALIFIER")
+        ).first()
+        setting.value = "staging"
+        session.add(setting)
+        session.commit()
+
+        mock_lambda_client.set_response({
+            "success": True,
+            "validation_passed": True,
+            "messages": {},
+            "errors": {},
+            "warnings": {},
+            "statusCode": 200
+        })
+
+        response = client.post(
+            "/api/v1/manifest/validate?manifest_uri=s3://test-bucket/manifest.csv"
+        )
+
+        assert response.status_code == 200
+        assert mock_lambda_client.invocations[-1]["Qualifier"] == "staging"
+
+    def test_validate_manifest_qualifier_defaults_to_main_when_setting_absent(
+        self, client: TestClient, mock_lambda_client, session: Session
+    ):
+        """Test that qualifier defaults to 'main' when setting is not in DB"""
+        from api.settings.models import Setting
+        from sqlmodel import select
+
+        # Remove the qualifier setting to test fallback
+        setting = session.exec(
+            select(Setting).where(Setting.key == "MANIFEST_VALIDATION_LAMBDA_QUALIFIER")
+        ).first()
+        if setting:
+            session.delete(setting)
+            session.commit()
+
+        mock_lambda_client.set_response({
+            "success": True,
+            "validation_passed": True,
+            "messages": {},
+            "errors": {},
+            "warnings": {},
+            "statusCode": 200
+        })
+
+        response = client.post(
+            "/api/v1/manifest/validate?manifest_uri=s3://test-bucket/manifest.csv"
+        )
+
+        assert response.status_code == 200
+        assert mock_lambda_client.invocations[-1]["Qualifier"] == "main"
 
     def test_validate_manifest_files_bucket_defaults_to_s3_path_bucket(
         self, client: TestClient, mock_lambda_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -614,6 +614,12 @@ def session_fixture():
             name="Manifest Validation Lambda",
             description="Test Lambda function for manifest validation"
         ),
+        Setting(
+            key="MANIFEST_VALIDATION_LAMBDA_QUALIFIER",
+            value="main",
+            name="Manifest Validation Lambda Qualifier",
+            description="Alias or version qualifier for the manifest validation Lambda"
+        ),
     ]
     for setting in test_settings:
         session.add(setting)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -471,17 +471,20 @@ class MockLambdaClient:
         """
         self.error_mode = error_type
 
-    def invoke(self, FunctionName: str, InvocationType: str, Payload: str):
+    def invoke(self, FunctionName: str, InvocationType: str, Payload: str, Qualifier: str = None):
         """Mock Lambda invoke operation"""
         import json
         from botocore.exceptions import NoCredentialsError, ClientError
 
         # Track the invocation
-        self.invocations.append({
+        invocation = {
             "FunctionName": FunctionName,
             "InvocationType": InvocationType,
             "Payload": json.loads(Payload)
-        })
+        }
+        if Qualifier:
+            invocation["Qualifier"] = Qualifier
+        self.invocations.append(invocation)
 
         # Check for simulated errors
         if self.error_mode == "NoCredentialsError":


### PR DESCRIPTION
previously, we invoked the lambda function with no qualifier, so $LATEST was run rather than the main/dev alias as desired. This PR checks for this setting as it does the lambda function name (falling back on "main" if the setting is undefined) and invokes the function with this value.