### PR TITLE
Feature/legacy samples search

### DIFF
--- a/api/legacy/models.py
+++ b/api/legacy/models.py
@@ -1,0 +1,36 @@
+"""
+Pydantic models for legacy /api/v0/samples/search endpoints.
+
+These models produce the response shape expected by legacy clients
+that have not migrated to the /api/v1 endpoints.
+"""
+
+from pydantic import BaseModel
+
+
+class LegacySampleHit(BaseModel):
+    """Single sample in legacy response format."""
+    samplename: str
+    projectid: str
+    tags: dict[str, str] | None = None
+
+
+class LegacySampleSearchResponse(BaseModel):
+    """GET /api/v0/samples/search response (no pagination)."""
+    total: int
+    hits: list[LegacySampleHit]
+
+
+class LegacySampleSearchPaginatedResponse(BaseModel):
+    """POST /api/v0/samples/search response (with pagination)."""
+    total: int
+    page: int
+    per_page: int
+    hits: list[LegacySampleHit]
+
+
+class LegacySampleSearchRequest(BaseModel):
+    """POST /api/v0/samples/search request body."""
+    filter_on: dict = {}
+    page: int = 1
+    per_page: int = 100

--- a/api/legacy/routes.py
+++ b/api/legacy/routes.py
@@ -1,0 +1,85 @@
+"""
+Legacy compatibility routes for /api/v0/samples/search.
+
+These endpoints accept the same inputs as the old Flask app's
+GET and POST /samples/search and return the old response format.
+"""
+
+from fastapi import APIRouter, Request
+from core.deps import SessionDep
+from api.legacy.models import (
+    LegacySampleSearchResponse,
+    LegacySampleSearchPaginatedResponse,
+    LegacySampleSearchRequest,
+)
+import api.legacy.services as services
+
+router = APIRouter(prefix="/samples", tags=["Legacy Endpoints"])
+
+
+@router.get(
+    "/search",
+    response_model=LegacySampleSearchResponse,
+)
+def legacy_search_samples_get(
+    request: Request,
+    session: SessionDep,
+) -> LegacySampleSearchResponse:
+    """
+    Search samples using query string parameters (legacy format).
+
+    Accepts key/value pairs as query params, e.g.:
+    ``?projectid=P-1234&samplename=Sample_1``
+
+    Top-level fields: ``projectid``, ``samplename``, ``created_on``
+    Any other key is matched against sample attributes (case-insensitive).
+
+    Returns all matching samples (no pagination).
+    """
+    # Convert query params to dict, excluding internal FastAPI params
+    query_params = {
+        k: v for k, v in request.query_params.items()
+        if k != "_"  # Legacy Flask clients may send _ for cache-busting
+    }
+    return services.search_samples_get(session=session, query_params=query_params)
+
+
+@router.post(
+    "/search",
+    response_model=LegacySampleSearchPaginatedResponse,
+)
+def legacy_search_samples_post(
+    session: SessionDep,
+    body: LegacySampleSearchRequest,
+) -> LegacySampleSearchPaginatedResponse:
+    """
+    Search samples using JSON body with filter_on, page, per_page (legacy format).
+
+    Example body::
+
+        {
+            "filter_on": {
+                "projectid": "P-1234",
+                "tags": {
+                    "USUBJID": "CA123012-01-234"
+                }
+            },
+            "page": 1,
+            "per_page": 100
+        }
+
+    ``filter_on`` supports:
+    - ``projectid`` (str or list)
+    - ``samplename`` (str or list)
+    - ``created_on`` (str, date prefix match)
+    - ``tags`` (dict of key/value pairs, matched case-insensitively)
+    - Any other key is matched against sample attributes
+
+    List values are OR'd; multiple keys are AND'd.
+    """
+    return services.search_samples_post(
+        session=session,
+        filter_on=body.filter_on,
+        page=body.page,
+        per_page=body.per_page,
+    )

--- a/api/legacy/services.py
+++ b/api/legacy/services.py
@@ -1,0 +1,171 @@
+"""
+Services for legacy /api/v0/samples/search endpoints.
+
+Translates legacy query patterns (from the Flask/ES app) to SQL queries
+against the current Sample + SampleAttribute tables.
+"""
+
+from datetime import datetime
+from sqlmodel import Session, select, func
+from sqlalchemy.orm import selectinload
+
+from api.samples.models import Sample, SampleAttribute
+from api.legacy.models import (
+    LegacySampleHit,
+    LegacySampleSearchResponse,
+    LegacySampleSearchPaginatedResponse,
+)
+
+
+# Top-level fields that map to Sample columns
+FIELD_MAP = {
+    "projectid": "project_id",
+    "samplename": "sample_id",
+}
+
+
+def _sample_to_hit(sample: Sample) -> LegacySampleHit:
+    """Convert a Sample ORM object to legacy response format."""
+    tags = {}
+    if sample.attributes:
+        for attr in sample.attributes:
+            tags[attr.key] = attr.value
+    return LegacySampleHit(
+        samplename=sample.sample_id,
+        projectid=sample.project_id,
+        tags=tags if tags else None,
+    )
+
+
+def _build_query(
+    filters: dict,
+    tags: dict | None = None,
+):
+    """
+    Build a SQLAlchemy select statement from legacy filter parameters.
+
+    Args:
+        filters: dict of top-level or attribute filters
+            - Keys in FIELD_MAP are mapped to Sample columns
+            - 'created_on' is handled as date prefix match
+            - 'tags' key (if present) is extracted and handled separately
+            - Other keys are treated as SampleAttribute key searches
+        tags: Explicit tags dict (from POST body's filter_on.tags)
+
+    Returns:
+        A select statement for Sample objects
+    """
+    statement = select(Sample).options(selectinload(Sample.attributes))
+
+    # Extract tags from filters if present
+    if tags is None:
+        tags = filters.pop("tags", None)
+    else:
+        filters.pop("tags", None)  # Remove if also present in filters
+
+    # Handle top-level and attribute filters
+    attr_filters = {}
+    for key, value in filters.items():
+        column_name = FIELD_MAP.get(key)
+        if column_name:
+            # Map to Sample column
+            column = getattr(Sample, column_name)
+            if isinstance(value, list):
+                statement = statement.where(column.in_(value))
+            else:
+                statement = statement.where(column == value)
+        elif key == "created_on":
+            # Date prefix match on Sample.created_at
+            # e.g., "2026-01-21" matches any timestamp on that date
+            if isinstance(value, str) and Sample.created_at is not None:
+                try:
+                    date = datetime.strptime(value, "%Y-%m-%d").date()
+                    statement = statement.where(
+                        func.date(Sample.created_at) == date
+                    )
+                except ValueError:
+                    pass  # Invalid date format, skip filter
+        else:
+            # Unknown key — treat as attribute filter
+            attr_filters[key] = value
+
+    # Handle attribute filters (from unknown keys)
+    for attr_key, attr_value in attr_filters.items():
+        # Case-insensitive key matching
+        attr_subquery = (
+            select(SampleAttribute.sample_id)
+            .where(
+                func.upper(SampleAttribute.key) == attr_key.upper(),
+                SampleAttribute.value == attr_value,
+            )
+        )
+        statement = statement.where(Sample.id.in_(attr_subquery))
+
+    # Handle tags dict (from POST body)
+    if tags and isinstance(tags, dict):
+        for tag_key, tag_value in tags.items():
+            attr_subquery = (
+                select(SampleAttribute.sample_id)
+                .where(
+                    func.upper(SampleAttribute.key) == tag_key.upper(),
+                    SampleAttribute.value == tag_value,
+                )
+            )
+            statement = statement.where(Sample.id.in_(attr_subquery))
+
+    return statement
+
+
+def search_samples_get(
+    session: Session,
+    query_params: dict,
+) -> LegacySampleSearchResponse:
+    """
+    Handle GET /api/v0/samples/search — no pagination, returns all matches.
+    """
+    # Make a mutable copy
+    filters = dict(query_params)
+
+    statement = _build_query(filters)
+    samples = session.exec(statement).all()
+
+    hits = [_sample_to_hit(s) for s in samples]
+    return LegacySampleSearchResponse(total=len(hits), hits=hits)
+
+
+def search_samples_post(
+    session: Session,
+    filter_on: dict,
+    page: int = 1,
+    per_page: int = 100,
+) -> LegacySampleSearchPaginatedResponse:
+    """
+    Handle POST /api/v0/samples/search — with pagination.
+    """
+    # Make mutable copies to avoid modifying caller's dict.
+    # Separate tags before calling _build_query since it mutates filters.
+    filters = {k: v for k, v in filter_on.items() if k != "tags"}
+    tags = filter_on.get("tags")
+
+    # Build query for total count (without pagination)
+    count_filters = dict(filters)
+    count_tags = dict(tags) if tags else None
+    count_stmt = _build_query(count_filters, count_tags)
+    all_results = session.exec(count_stmt).all()
+    total = len(all_results)
+
+    # Build query with pagination
+    page_filters = dict(filters)
+    page_tags = dict(tags) if tags else None
+    statement = _build_query(page_filters, page_tags)
+    offset = (page - 1) * per_page
+    statement = statement.offset(offset).limit(per_page)
+    samples = session.exec(statement).all()
+
+    hits = [_sample_to_hit(s) for s in samples]
+    return LegacySampleSearchPaginatedResponse(
+        total=total,
+        page=page,
+        per_page=per_page,
+        hits=hits,
+    )

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ from api.workflow.routes import router as workflow_router
 from api.workflow.routes import run_router as workflow_run_router
 from api.pipeline.routes import router as pipeline_router
 from api.platforms.routes import router as platforms_router
+from api.legacy.routes import router as legacy_router
 
 
 # Customize route id's
@@ -139,6 +140,10 @@ app.include_router(workflow_router, prefix=API_PREFIX)
 app.include_router(workflow_run_router, prefix=API_PREFIX)
 app.include_router(pipeline_router, prefix=API_PREFIX)
 app.include_router(platforms_router, prefix=API_PREFIX)
+
+# Legacy compatibility routers
+LEGACY_PREFIX = "/api/v0"
+app.include_router(legacy_router, prefix=LEGACY_PREFIX)
 
 
 if __name__ == "__main__":

--- a/tests/api/test_legacy_samples_search.py
+++ b/tests/api/test_legacy_samples_search.py
@@ -1,0 +1,382 @@
+"""
+Tests for legacy /api/v0/samples/search compatibility endpoints.
+"""
+
+from sqlmodel import Session
+from fastapi.testclient import TestClient
+from datetime import datetime, timezone
+
+from api.project.models import Project
+from api.samples.models import Sample, SampleAttribute
+from api.project.services import generate_project_id
+
+
+def _create_project(session: Session, name: str = "Test Project") -> Project:
+    """Helper to create a project."""
+    project = Project(name=name)
+    project.project_id = generate_project_id(session=session)
+    project.attributes = []
+    session.add(project)
+    session.flush()
+    return project
+
+
+def _create_sample(
+    session: Session,
+    project: Project,
+    sample_id: str,
+    attributes: dict | None = None,
+    created_at: datetime | None = None,
+) -> Sample:
+    """Helper to create a sample with optional attributes."""
+    sample = Sample(
+        sample_id=sample_id,
+        project_id=project.project_id,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    session.add(sample)
+    session.flush()
+
+    if attributes:
+        for key, value in attributes.items():
+            attr = SampleAttribute(sample_id=sample.id, key=key, value=value)
+            session.add(attr)
+
+    session.flush()
+    return sample
+
+
+# ──────────────────────────────────────────────────────────────────
+# GET /api/v0/samples/search
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestLegacyGetSearch:
+    """Tests for GET /api/v0/samples/search"""
+
+    def test_search_by_projectid(self, client: TestClient, session: Session):
+        """Search by projectid returns matching samples."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {"Tissue": "Liver"})
+        _create_sample(session, project, "S2", {"Tissue": "Heart"})
+        session.commit()
+
+        response = client.get(
+            "/api/v0/samples/search",
+            params={"projectid": project.project_id},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["hits"]) == 2
+        # Verify response shape
+        for hit in data["hits"]:
+            assert "samplename" in hit
+            assert "projectid" in hit
+            assert hit["projectid"] == project.project_id
+
+    def test_search_by_samplename(self, client: TestClient, session: Session):
+        """Search by samplename returns the matching sample."""
+        project = _create_project(session)
+        _create_sample(session, project, "MySample", {"Tissue": "Liver"})
+        _create_sample(session, project, "Other", {"Tissue": "Heart"})
+        session.commit()
+
+        response = client.get(
+            "/api/v0/samples/search",
+            params={"samplename": "MySample"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["hits"][0]["samplename"] == "MySample"
+
+    def test_combined_search(self, client: TestClient, session: Session):
+        """Combined projectid + samplename returns intersection."""
+        p1 = _create_project(session, "P1")
+        p2 = _create_project(session, "P2")
+        _create_sample(session, p1, "SharedName")
+        _create_sample(session, p2, "SharedName")
+        session.commit()
+
+        response = client.get(
+            "/api/v0/samples/search",
+            params={"projectid": p1.project_id, "samplename": "SharedName"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["hits"][0]["projectid"] == p1.project_id
+
+    def test_search_by_attribute_as_query_param(self, client: TestClient, session: Session):
+        """Unknown query params are searched as attributes (case-insensitive key)."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {"ASSAY_METHOD": "RNA-Seq"})
+        _create_sample(session, project, "S2", {"ASSAY_METHOD": "WES"})
+        session.commit()
+
+        # lowercase key should match uppercase attribute
+        response = client.get(
+            "/api/v0/samples/search",
+            params={"assay_method": "RNA-Seq"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["hits"][0]["samplename"] == "S1"
+
+    def test_search_by_created_on(self, client: TestClient, session: Session):
+        """Search by created_on matches date prefix of created_at."""
+        project = _create_project(session)
+        _create_sample(
+            session, project, "S1",
+            created_at=datetime(2026, 1, 21, 10, 30, 0, tzinfo=timezone.utc),
+        )
+        _create_sample(
+            session, project, "S2",
+            created_at=datetime(2026, 1, 22, 10, 30, 0, tzinfo=timezone.utc),
+        )
+        session.commit()
+
+        response = client.get(
+            "/api/v0/samples/search",
+            params={"created_on": "2026-01-21"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["hits"][0]["samplename"] == "S1"
+
+    def test_empty_results(self, client: TestClient, session: Session):
+        """Non-matching query returns empty results."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        session.commit()
+
+        response = client.get(
+            "/api/v0/samples/search",
+            params={"projectid": "nonexistent"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0
+        assert data["hits"] == []
+
+    def test_tags_are_flat_dict(self, client: TestClient, session: Session):
+        """Verify tags in response are flat dict format."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {
+            "Tissue": "Liver",
+            "ASSAY_METHOD": "RNA-Seq",
+            "CREATED_BY": "testuser",
+        })
+        session.commit()
+
+        response = client.get(
+            "/api/v0/samples/search",
+            params={"projectid": project.project_id},
+        )
+        assert response.status_code == 200
+        hit = response.json()["hits"][0]
+        assert isinstance(hit["tags"], dict)
+        assert hit["tags"]["Tissue"] == "Liver"
+        assert hit["tags"]["ASSAY_METHOD"] == "RNA-Seq"
+        assert hit["tags"]["CREATED_BY"] == "testuser"
+
+    def test_sample_without_attributes_has_null_tags(self, client: TestClient, session: Session):
+        """Sample with no attributes returns tags as null."""
+        project = _create_project(session)
+        _create_sample(session, project, "BareSample")
+        session.commit()
+
+        response = client.get(
+            "/api/v0/samples/search",
+            params={"samplename": "BareSample"},
+        )
+        assert response.status_code == 200
+        hit = response.json()["hits"][0]
+        assert hit["tags"] is None
+
+    def test_no_params_returns_all(self, client: TestClient, session: Session):
+        """GET with no params returns all samples."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        _create_sample(session, project, "S2")
+        session.commit()
+
+        response = client.get("/api/v0/samples/search")
+        assert response.status_code == 200
+        assert response.json()["total"] == 2
+
+
+# ──────────────────────────────────────────────────────────────────
+# POST /api/v0/samples/search
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestLegacyPostSearch:
+    """Tests for POST /api/v0/samples/search"""
+
+    def test_post_basic_filter(self, client: TestClient, session: Session):
+        """POST with projectid filter returns matching samples."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        _create_sample(session, project, "S2")
+        session.commit()
+
+        response = client.post(
+            "/api/v0/samples/search",
+            json={"filter_on": {"projectid": project.project_id}},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert data["page"] == 1
+        assert data["per_page"] == 100
+
+    def test_post_tag_filter(self, client: TestClient, session: Session):
+        """POST with tags filter matches attributes."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {"USUBJID": "CA123-01"})
+        _create_sample(session, project, "S2", {"USUBJID": "CA123-02"})
+        session.commit()
+
+        response = client.post(
+            "/api/v0/samples/search",
+            json={
+                "filter_on": {
+                    "tags": {"USUBJID": "CA123-01"},
+                },
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["hits"][0]["samplename"] == "S1"
+
+    def test_post_combined_filter(self, client: TestClient, session: Session):
+        """POST with projectid + tags combined."""
+        p1 = _create_project(session, "P1")
+        p2 = _create_project(session, "P2")
+        _create_sample(session, p1, "S1", {"USUBJID": "CA123-01"})
+        _create_sample(session, p2, "S2", {"USUBJID": "CA123-01"})
+        session.commit()
+
+        response = client.post(
+            "/api/v0/samples/search",
+            json={
+                "filter_on": {
+                    "projectid": p1.project_id,
+                    "tags": {"USUBJID": "CA123-01"},
+                },
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["hits"][0]["projectid"] == p1.project_id
+
+    def test_post_list_values_or(self, client: TestClient, session: Session):
+        """POST with list values for projectid matches any (OR)."""
+        p1 = _create_project(session, "P1")
+        p2 = _create_project(session, "P2")
+        p3 = _create_project(session, "P3")
+        _create_sample(session, p1, "S1")
+        _create_sample(session, p2, "S2")
+        _create_sample(session, p3, "S3")
+        session.commit()
+
+        response = client.post(
+            "/api/v0/samples/search",
+            json={
+                "filter_on": {
+                    "projectid": [p1.project_id, p2.project_id],
+                },
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+
+    def test_post_pagination(self, client: TestClient, session: Session):
+        """POST respects page and per_page, total is full count."""
+        project = _create_project(session)
+        for i in range(5):
+            _create_sample(session, project, f"S{i}")
+        session.commit()
+
+        # Page 1, per_page=2
+        response = client.post(
+            "/api/v0/samples/search",
+            json={
+                "filter_on": {"projectid": project.project_id},
+                "page": 1,
+                "per_page": 2,
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 5
+        assert data["page"] == 1
+        assert data["per_page"] == 2
+        assert len(data["hits"]) == 2
+
+        # Page 3, per_page=2 — should get 1 result
+        response = client.post(
+            "/api/v0/samples/search",
+            json={
+                "filter_on": {"projectid": project.project_id},
+                "page": 3,
+                "per_page": 2,
+            },
+        )
+        data = response.json()
+        assert data["total"] == 5
+        assert len(data["hits"]) == 1
+
+    def test_post_case_insensitive_tag_keys(self, client: TestClient, session: Session):
+        """POST tag search is case-insensitive on keys."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {"ASSAY_METHOD": "RNA-Seq"})
+        session.commit()
+
+        # lowercase key should match uppercase attribute
+        response = client.post(
+            "/api/v0/samples/search",
+            json={
+                "filter_on": {
+                    "tags": {"assay_method": "RNA-Seq"},
+                },
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["total"] == 1
+
+    def test_post_empty_filter_returns_all(self, client: TestClient, session: Session):
+        """POST with empty filter_on returns all samples."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        _create_sample(session, project, "S2")
+        session.commit()
+
+        response = client.post(
+            "/api/v0/samples/search",
+            json={"filter_on": {}},
+        )
+        assert response.status_code == 200
+        assert response.json()["total"] == 2
+
+    def test_post_empty_body_uses_defaults(self, client: TestClient, session: Session):
+        """POST with minimal body uses defaults for page and per_page."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        session.commit()
+
+        response = client.post(
+            "/api/v0/samples/search",
+            json={},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["page"] == 1
+        assert data["per_page"] == 100


### PR DESCRIPTION
the new sample endpoint return format has a very different API contract than the legacy server and some client applications will take time to migrate. here, we add a GET and a POST /api/**v0**/samples/search matching the legacy contract without affecting the v1 endpoints.