### PR TITLE
Feature/skip limit pagination

### DIFF
--- a/api/project/routes.py
+++ b/api/project/routes.py
@@ -329,8 +329,10 @@ def bulk_create_samples(
 def get_project_samples(
     session: SessionDep,
     project: ProjectDep,
-    page: int = Query(1, description="Page number (1-indexed)"),
-    per_page: int = Query(20, description="Number of items per page"),
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(
+        100, ge=1, le=10000, description="Maximum number of records to return"
+    ),
     sort_by: str = Query("sample_id", description="Field to sort by"),
     sort_order: Literal["asc", "desc"] = Query(
         "asc", description="Sort order (asc or desc)"
@@ -340,15 +342,17 @@ def get_project_samples(
     ),
 ) -> SamplesWithFilesPublic | SamplesPublic:
     """
-    Returns a paginated list of samples.
+    Returns a list of samples for a project.
 
-    Pass ``?include=files`` to eagerly load file metadata for each sample.
+    Pagination is offset-based: ``skip`` is the number of records to skip
+    and ``limit`` caps the page size. Pass ``?include=files`` to eagerly
+    load file metadata for each sample.
     """
     return services.get_project_samples(
         session=session,
         project=project,
-        page=page,
-        per_page=per_page,
+        skip=skip,
+        limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
         include=include,

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -769,8 +769,8 @@ def get_project_samples(
     *,
     session: Session,
     project: Project,
-    page: PositiveInt,
-    per_page: PositiveInt,
+    skip: int = 0,
+    limit: int = 100,
     sort_by: str,
     sort_order: Literal["asc", "desc"],
     include: list[str] | None = None,
@@ -781,8 +781,8 @@ def get_project_samples(
     Args:
         session: Database session
         project: The project object (already validated)
-        page: Page number (1-based)
-        per_page: Number of items per page
+        skip: Number of records to skip (offset).
+        limit: Maximum number of records to return.
         sort_by: Column name to sort by
         sort_order: Sort direction ('asc' or 'desc')
         include: Optional list of related data to include (e.g. ``["files"]``)
@@ -800,12 +800,6 @@ def get_project_samples(
     total_count = session.exec(
         select(func.count()).select_from(Sample).where(Sample.project_id == project.project_id)
     ).one()
-
-    # Compute total pages
-    total_pages = (total_count + per_page - 1) // per_page  # Ceiling division
-
-    # Calculate offset for pagination
-    offset = (page - 1) * per_page
 
     # Build the select statement
     statement = select(Sample).where(Sample.project_id == project.project_id)
@@ -826,7 +820,7 @@ def get_project_samples(
         statement = statement.order_by(sort_column)
 
     # Add pagination
-    statement = statement.offset(offset).limit(per_page)
+    statement = statement.offset(skip).limit(limit)
 
     # Execute the query
     samples = session.exec(statement).all()
@@ -862,11 +856,10 @@ def get_project_samples(
             data=public_samples,
             data_cols=data_cols,
             total_items=total_count,
-            total_pages=total_pages,
-            current_page=page,
-            per_page=per_page,
-            has_next=page < total_pages,
-            has_prev=page > 1,
+            skip=skip,
+            limit=limit,
+            has_next=(skip + limit) < total_count,
+            has_prev=skip > 0,
         )
 
     # Default: no files
@@ -883,11 +876,10 @@ def get_project_samples(
         data=public_samples_plain,
         data_cols=data_cols,
         total_items=total_count,
-        total_pages=total_pages,
-        current_page=page,
-        per_page=per_page,
-        has_next=page < total_pages,
-        has_prev=page > 1,
+        skip=skip,
+        limit=limit,
+        has_next=(skip + limit) < total_count,
+        has_prev=skip > 0,
     )
 
 

--- a/api/samples/models.py
+++ b/api/samples/models.py
@@ -73,9 +73,8 @@ class SamplesPublic(SQLModel):
     data: List[SamplePublic]
     data_cols: list[str] | None = None
     total_items: int
-    total_pages: int
-    current_page: int
-    per_page: int
+    skip: int
+    limit: int
     has_next: bool
     has_prev: bool
 
@@ -101,9 +100,8 @@ class SamplesWithFilesPublic(SQLModel):
     data: List[SampleWithFilesPublic]
     data_cols: list[str] | None = None
     total_items: int
-    total_pages: int
-    current_page: int
-    per_page: int
+    skip: int
+    limit: int
     has_next: bool
     has_prev: bool
 

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -2,7 +2,6 @@ import uuid
 from typing import List, Literal
 
 from fastapi import HTTPException, status
-from pydantic import PositiveInt
 from sqlmodel import Session, select, func
 from opensearchpy import OpenSearch
 

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -136,8 +136,8 @@ def get_samples(
     *,
     session: Session,
     project_id: str,
-    page: PositiveInt,
-    per_page: PositiveInt,
+    skip: int = 0,
+    limit: int = 100,
     sort_by: str,
     sort_order: Literal["asc", "desc"],
 ) -> SamplesPublic:
@@ -147,8 +147,8 @@ def get_samples(
     Args:
         session: Database session
         project_id: Project ID to filter samples by
-        page: Page number (1-based)
-        per_page: Number of items per page
+        skip: Number of records to skip (offset)
+        limit: Maximum number of records to return
         sort_by: Column name to sort by
         sort_order: Sort direction ('asc' or 'desc')
 
@@ -159,12 +159,6 @@ def get_samples(
     total_count = session.exec(
         select(func.count()).select_from(Sample).where(Sample.project_id == project_id)
     ).one()
-
-    # Compute total pages
-    total_pages = (total_count + per_page - 1) // per_page  # Ceiling division
-
-    # Calculate offset for pagination
-    offset = (page - 1) * per_page
 
     # Build the select statement
     statement = select(Sample).where(Sample.project_id == project_id)
@@ -177,7 +171,7 @@ def get_samples(
         statement = statement.order_by(sort_column)
 
     # Add pagination
-    statement = statement.offset(offset).limit(per_page)
+    statement = statement.offset(skip).limit(limit)
 
     # Execute the query
     samples = session.exec(statement).all()
@@ -188,9 +182,6 @@ def get_samples(
             sample_id=sample.sample_id,
             project_id=sample.project_id,
             attributes=sample.attributes,
-            # [
-            #    {"key": attr.key, "value": attr.value} for attr in (sample.attributes or [])
-            # ] if sample.attributes else []
         )
         for sample in samples
     ]
@@ -209,11 +200,10 @@ def get_samples(
         data=public_samples,
         data_cols=data_cols,
         total_items=total_count,
-        total_pages=total_pages,
-        current_page=page,
-        per_page=per_page,
-        has_next=page < total_pages,
-        has_prev=page > 1,
+        skip=skip,
+        limit=limit,
+        has_next=(skip + limit) < total_count,
+        has_prev=skip > 0,
     )
 
 

--- a/api/vendors/models.py
+++ b/api/vendors/models.py
@@ -55,8 +55,7 @@ class VendorsPublic(SQLModel):
     """
     data: list[VendorPublic]
     total_items: int
-    total_pages: int
-    current_page: int
-    per_page: int
+    skip: int
+    limit: int
     has_next: bool
     has_prev: bool

--- a/api/vendors/routes.py
+++ b/api/vendors/routes.py
@@ -51,8 +51,10 @@ def add_vendor(
 )
 def get_vendors(
     session: SessionDep,
-    page: int = Query(1, description="Page number (1-indexed)"),
-    per_page: int = Query(20, description="Number of items per page"),
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(
+        100, ge=1, le=10000, description="Maximum number of records to return"
+    ),
     sort_by: str = Query("vendor_id", description="Field to sort by"),
     sort_order: Literal["asc", "desc"] = Query(
         "asc", description="Sort order (asc or desc)"
@@ -63,8 +65,8 @@ def get_vendors(
     """
     return services.get_vendors(
         session=session,
-        page=page,
-        per_page=per_page,
+        skip=skip,
+        limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
     )

--- a/api/vendors/services.py
+++ b/api/vendors/services.py
@@ -41,17 +41,14 @@ def add_vendor(session: SessionDep, vendor_in: VendorCreate) -> VendorPublic:
 
 def get_vendors(
     session: SessionDep,
-    page: int,
-    per_page: int,
+    skip: int,
+    limit: int,
     sort_by: str,
     sort_order: str
 ) -> VendorsPublic:
     """ Get list of vendors """
-    # Get total run count
+    # Get total vendor count
     total_count = session.exec(select(func.count()).select_from(Vendor)).one()
-
-    # Compute total pages
-    total_pages = (total_count + per_page - 1) // per_page  # Ceiling division
 
     sort_field = getattr(Vendor, sort_by, Vendor.vendor_id)
     sort_direction = sort_field.asc() if sort_order == "asc" else sort_field.desc()
@@ -60,8 +57,8 @@ def get_vendors(
     vendors = session.exec(
         select(Vendor)
         .order_by(sort_direction)
-        .limit(per_page)
-        .offset((page - 1) * per_page)
+        .offset(skip)
+        .limit(limit)
     ).all()
 
     # Map to vendor
@@ -72,11 +69,10 @@ def get_vendors(
     return VendorsPublic(
         data=vendors_public,
         total_items=total_count,
-        total_pages=total_pages,
-        current_page=page,
-        per_page=per_page,
-        has_next=page < total_pages,
-        has_prev=page > 1,
+        skip=skip,
+        limit=limit,
+        has_next=(skip + limit) < total_count,
+        has_prev=skip > 0,
     )
 
 

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -24,12 +24,11 @@ def test_get_samples_for_a_project_with_no_samples(
     response = client.get(f"/api/v1/projects/{new_project.project_id}/samples")
     assert response.status_code == 200
     assert response.json() == {
-        "current_page": 1,
         "data": [],
         "data_cols": None,
-        "per_page": 20,
         "total_items": 0,
-        "total_pages": 0,
+        "skip": 0,
+        "limit": 100,
         "has_next": False,
         "has_prev": False,
     }
@@ -472,17 +471,17 @@ def test_get_samples_include_files_pagination_works(
         )
     session.commit()
 
-    # Page 1, per_page=2
+    # First page: skip=0, limit=2
     response = client.get(
         f"/api/v1/projects/{project.project_id}/samples",
-        params={"include": "files", "per_page": 2, "page": 1},
+        params={"include": "files", "limit": 2, "skip": 0},
     )
     assert response.status_code == 200
 
     data = response.json()
     assert data["total_items"] == 5
-    assert data["per_page"] == 2
-    assert data["current_page"] == 1
+    assert data["limit"] == 2
+    assert data["skip"] == 0
     assert data["has_next"] is True
     assert len(data["data"]) == 2
 
@@ -491,10 +490,10 @@ def test_get_samples_include_files_pagination_works(
         assert sample_item["files"] is not None
         assert len(sample_item["files"]) == 1
 
-    # Page 3 (last), per_page=2 → 1 sample
+    # Last page: skip=4, limit=2 → 1 sample
     response = client.get(
         f"/api/v1/projects/{project.project_id}/samples",
-        params={"include": "files", "per_page": 2, "page": 3},
+        params={"include": "files", "limit": 2, "skip": 4},
     )
     assert response.status_code == 200
 


### PR DESCRIPTION
Update the sample and vendor endpoints to use skip/limit rather than page/per_page.

Skip/limit allows fetching a smaller set of initial data to render while loading additional data in the background. Page/per_page could be used, but requires re-fetching the initial request. Skip/limit keeps the code cleaner.

Sample and vendor endpoints are updated here because they were the only ones that used the `use-all-paginated` hook. The other endpoints (projects, and runs) could also be migrated for consistency, but it isn't strictly necessary.