### PR TITLE
Bugfix case insensitive duplicate key checking

### DIFF
--- a/api/pipeline/services.py
+++ b/api/pipeline/services.py
@@ -41,9 +41,10 @@ def create_pipeline(
 
     # Handle attributes
     if pipeline_in.attributes:
+        # Prevent duplicate keys (case-insensitive to match MySQL collation)
         seen: set[str] = set()
         keys = [attr.key for attr in pipeline_in.attributes]
-        dups = [k for k in keys if k in seen or seen.add(k)]
+        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
         if dups:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/pipeline/services.py
+++ b/api/pipeline/services.py
@@ -6,6 +6,7 @@ CRUD operations for Pipeline, PipelineAttribute, and PipelineWorkflow entities.
 from uuid import UUID
 
 from fastapi import HTTPException, status
+from api.utils import check_duplicate_attribute_keys
 from sqlmodel import Session, select, func
 
 from api.workflow.models import Attribute, Workflow
@@ -41,18 +42,9 @@ def create_pipeline(
 
     # Handle attributes
     if pipeline_in.attributes:
-        # Prevent duplicate keys (case-insensitive to match MySQL collation)
-        seen: set[str] = set()
-        keys = [attr.key for attr in pipeline_in.attributes]
-        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
-        if dups:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    f"Duplicate keys ({', '.join(dups)}) are not allowed "
-                    f"in pipeline attributes."
-                ),
-            )
+        check_duplicate_attribute_keys(
+            pipeline_in.attributes, "pipeline attributes"
+        )
 
         attrs = [
             PipelineAttribute(

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -713,10 +713,10 @@ def add_sample_to_project(
 
     # Handle attribute mapping
     if sample_in.attributes:
-        # Prevent duplicate keys
-        seen = set()
+        # Prevent duplicate keys (case-insensitive to match MySQL collation)
+        seen: set[str] = set()
         keys = [attr.key for attr in sample_in.attributes]
-        dups = [k for k in keys if k in seen or seen.add(k)]
+        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
         if dups:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -915,17 +915,21 @@ def update_sample_in_project(
             detail=f"Sample {sample_id} in project {project.project_id} not found.",
         )
 
-    # Check if the attribute exists
+    # Check if the attribute exists (case-insensitive key lookup to
+    # match MySQL's default collation and avoid duplicate-key errors)
     sample_attribute = session.exec(
         select(SampleAttribute).where(
             SampleAttribute.sample_id == sample.id,
-            SampleAttribute.key == attribute.key
+            func.lower(SampleAttribute.key) == attribute.key.lower()
         )
     ).first()
 
     if sample_attribute:
         # Update existing attribute
         sample_attribute.value = attribute.value
+        # Adopt the incoming key casing so the DB stays consistent
+        if sample_attribute.key != attribute.key:
+            sample_attribute.key = attribute.key
     else:
         # Create new attribute
         new_attribute = SampleAttribute(

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -87,10 +87,10 @@ def create_project(
 
     # Handle attribute mapping
     if project_in.attributes:
-        # Prevent duplicate keys
+        # Prevent duplicate keys (case-insensitive to match MySQL collation)
         seen = set()
         keys = [attr.key for attr in project_in.attributes]
-        dups = [k for k in keys if k in seen or seen.add(k)]
+        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
         if dups:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -268,10 +268,10 @@ def update_project(
 
     # Handle attributes if provided
     if update_request.attributes is not None:
-        # Prevent duplicate keys
+        # Prevent duplicate keys (case-insensitive to match MySQL collation)
         seen = set()
         keys = [attr.key for attr in update_request.attributes]
-        dups = [k for k in keys if k in seen or seen.add(k)]
+        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
         if dups:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -356,10 +356,10 @@ def patch_project(
         update_request.attributes is not None
         and len(update_request.attributes) > 0
     ):
-        # Prevent duplicate keys in the request
+        # Prevent duplicate keys in the request (case-insensitive to match MySQL collation)
         seen = set()
         keys = [attr.key for attr in update_request.attributes]
-        dups = [k for k in keys if k in seen or seen.add(k)]
+        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
         if dups:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -369,16 +369,22 @@ def patch_project(
                 ),
             )
 
+        # Load all existing attributes and build case-insensitive lookup map
+        existing_attrs = session.exec(
+            select(ProjectAttribute).where(
+                ProjectAttribute.project_id == project.id
+            )
+        ).all()
+        attr_map = {a.key.lower(): a for a in existing_attrs}
+
         for attr in update_request.attributes:
-            existing_attr = session.exec(
-                select(ProjectAttribute).where(
-                    ProjectAttribute.project_id == project.id,
-                    ProjectAttribute.key == attr.key,
-                )
-            ).first()
+            existing_attr = attr_map.get(attr.key.lower())
 
             if existing_attr:
                 existing_attr.value = attr.value
+                # Adopt the incoming key casing so the DB stays consistent
+                if existing_attr.key != attr.key:
+                    existing_attr.key = attr.key
             else:
                 session.add(
                     ProjectAttribute(

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -915,14 +915,14 @@ def update_sample_in_project(
             detail=f"Sample {sample_id} in project {project.project_id} not found.",
         )
 
-    # Check if the attribute exists (case-insensitive key lookup to
-    # match MySQL's default collation and avoid duplicate-key errors)
-    sample_attribute = session.exec(
-        select(SampleAttribute).where(
-            SampleAttribute.sample_id == sample.id,
-            func.lower(SampleAttribute.key) == attribute.key.lower()
-        )
-    ).first()
+    # Load all attributes for this sample and build a case-insensitive
+    # lookup map (avoids func.lower() in SQL which suppresses index use
+    # and mirrors the approach in bulk_create_samples).
+    existing_attrs = session.exec(
+        select(SampleAttribute).where(SampleAttribute.sample_id == sample.id)
+    ).all()
+    attr_map = {a.key.lower(): a for a in existing_attrs}
+    sample_attribute = attr_map.get(attribute.key.lower())
 
     if sample_attribute:
         # Update existing attribute

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Literal
 import boto3
 from fastapi import HTTPException, status
+from api.utils import check_duplicate_attribute_keys
 from pydantic import PositiveInt
 from pytz import timezone
 from sqlmodel import Session, func, select
@@ -87,15 +88,9 @@ def create_project(
 
     # Handle attribute mapping
     if project_in.attributes:
-        # Prevent duplicate keys (case-insensitive to match MySQL collation)
-        seen = set()
-        keys = [attr.key for attr in project_in.attributes]
-        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
-        if dups:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Duplicate keys ({', '.join(dups)}) are not allowed in project attributes.",
-            )
+        check_duplicate_attribute_keys(
+            project_in.attributes, "project attributes"
+        )
 
         # Parse and create project attributes
         # linking to new project
@@ -268,15 +263,9 @@ def update_project(
 
     # Handle attributes if provided
     if update_request.attributes is not None:
-        # Prevent duplicate keys (case-insensitive to match MySQL collation)
-        seen = set()
-        keys = [attr.key for attr in update_request.attributes]
-        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
-        if dups:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Duplicate keys ({', '.join(dups)}) are not allowed in project attributes.",
-            )
+        check_duplicate_attribute_keys(
+            update_request.attributes, "project attributes"
+        )
 
         # Delete all existing attributes for this project
         existing_attributes = session.exec(
@@ -356,18 +345,9 @@ def patch_project(
         update_request.attributes is not None
         and len(update_request.attributes) > 0
     ):
-        # Prevent duplicate keys in the request (case-insensitive to match MySQL collation)
-        seen = set()
-        keys = [attr.key for attr in update_request.attributes]
-        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
-        if dups:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    f"Duplicate keys ({', '.join(dups)}) are not "
-                    f"allowed in project attributes."
-                ),
-            )
+        check_duplicate_attribute_keys(
+            update_request.attributes, "project attributes"
+        )
 
         # Load all existing attributes and build case-insensitive lookup map
         existing_attrs = session.exec(
@@ -719,15 +699,9 @@ def add_sample_to_project(
 
     # Handle attribute mapping
     if sample_in.attributes:
-        # Prevent duplicate keys (case-insensitive to match MySQL collation)
-        seen: set[str] = set()
-        keys = [attr.key for attr in sample_in.attributes]
-        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
-        if dups:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Duplicate keys ({', '.join(dups)}) are not allowed in sample attributes.",
-            )
+        check_duplicate_attribute_keys(
+            sample_in.attributes, "sample attributes"
+        )
 
         # Create sample attributes
         sample_attributes = [

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -3,6 +3,7 @@ import uuid
 from typing import List, Literal
 
 from fastapi import HTTPException, status
+from api.utils import check_duplicate_attribute_keys
 from sqlmodel import Session, select, func
 from opensearchpy import OpenSearch
 
@@ -104,15 +105,9 @@ def add_sample_to_project(
 
     # Handle attribute mapping
     if sample_in.attributes:
-        # Prevent duplicate keys (case-insensitive to match MySQL collation)
-        seen = set()
-        keys = [attr.key for attr in sample_in.attributes]
-        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
-        if dups:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Duplicate keys ({', '.join(dups)}) are not allowed in project attributes.",
-            )
+        check_duplicate_attribute_keys(
+            sample_in.attributes, "sample attributes"
+        )
 
         # Parse and create project attributes (skip empty/whitespace-only values)
         sample_attributes = [

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -534,15 +534,17 @@ def bulk_create_samples(
             ),
         )
 
-    # 3. Validate no duplicate attribute keys per sample
+    # 3. Validate no duplicate attribute keys per sample (case-insensitive,
+    #    matching MySQL's default collation behaviour)
     for item in samples_in:
         if item.attributes:
             seen_keys: set[str] = set()
             dup_keys: list[str] = []
             for attr in item.attributes:
-                if attr.key in seen_keys:
+                key_lower = attr.key.lower() if attr.key else ""
+                if key_lower in seen_keys:
                     dup_keys.append(attr.key)
-                seen_keys.add(attr.key)
+                seen_keys.add(key_lower)
             if dup_keys:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -582,17 +584,20 @@ def bulk_create_samples(
 
             # ── Merge/upsert attributes on existing sample ────────
             if item.attributes:
-                # Build a map of existing attributes for this sample
+                # Build a case-insensitive map of existing attributes
+                # so that e.g. "SAMPLENAME_VENDOR" matches "samplename_vendor"
+                # (MySQL's default collation is case-insensitive).
                 existing_attrs = session.exec(
                     select(SampleAttribute).where(
                         SampleAttribute.sample_id == sample.id
                     )
                 ).all()
-                existing_attr_map = {a.key: a for a in existing_attrs}
+                existing_attr_map = {a.key.lower(): a for a in existing_attrs}
 
                 for attr in item.attributes:
                     is_empty = attr.value is None or attr.value.strip() == ""
-                    ea = existing_attr_map.get(attr.key)
+                    key_lower = attr.key.lower() if attr.key else ""
+                    ea = existing_attr_map.get(key_lower)
 
                     if is_empty:
                         # Column present but value blank → delete
@@ -602,6 +607,11 @@ def bulk_create_samples(
                     elif ea:
                         if ea.value != attr.value:
                             ea.value = attr.value
+                            updated = True
+                        # Adopt the incoming key casing so the DB
+                        # stays consistent with the latest upload.
+                        if ea.key != attr.key:
+                            ea.key = attr.key
                             updated = True
                     else:
                         session.add(

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -104,10 +104,10 @@ def add_sample_to_project(
 
     # Handle attribute mapping
     if sample_in.attributes:
-        # Prevent duplicate keys
+        # Prevent duplicate keys (case-insensitive to match MySQL collation)
         seen = set()
         keys = [attr.key for attr in sample_in.attributes]
-        dups = [k for k in keys if k in seen or seen.add(k)]
+        dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
         if dups:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,7 +1,5 @@
 """Shared utilities for the API layer."""
 
-from __future__ import annotations
-
 from typing import Sequence
 
 from fastapi import HTTPException, status

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,0 +1,38 @@
+"""Shared utilities for the API layer."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from fastapi import HTTPException, status
+
+
+def check_duplicate_attribute_keys(
+    attributes: Sequence,
+    entity_name: str = "attributes",
+) -> None:
+    """Raise HTTP 400 if any attribute keys collide case-insensitively.
+
+    This mirrors MySQL's default (case-insensitive) collation behaviour
+    for ``UniqueConstraint("..._id", "key")`` on attribute tables.
+
+    Args:
+        attributes: Sequence of objects with a ``.key`` attribute
+            (e.g. ``Attribute``, ``SampleCreate.attributes``).
+        entity_name: Label used in the error message, e.g.
+            ``"project attributes"`` or ``"sample attributes"``.
+
+    Raises:
+        HTTPException: 400 with a detail listing the duplicate keys.
+    """
+    seen: set[str] = set()
+    keys = [attr.key for attr in attributes]
+    dups = [k for k in keys if k.lower() in seen or seen.add(k.lower())]
+    if dups:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Duplicate keys ({', '.join(dups)}) are not "
+                f"allowed in {entity_name}."
+            ),
+        )

--- a/tests/api/test_bulk_samples.py
+++ b/tests/api/test_bulk_samples.py
@@ -549,7 +549,7 @@ class TestBulkSampleCreation:
     def test_bulk_case_insensitive_duplicate_attribute_keys_rejected(
         self, client: TestClient, session: Session
     ):
-        """Duplicate attribute keys differing only in case should be rejected."""
+        """Test that bulk create rejects samples with attribute keys differing only in case."""
         pid = _create_project(session)
 
         response = client.post(

--- a/tests/api/test_bulk_samples.py
+++ b/tests/api/test_bulk_samples.py
@@ -546,6 +546,29 @@ class TestBulkSampleCreation:
         assert response.status_code == 400
         assert "duplicate" in response.json()["detail"].lower()
 
+    def test_bulk_case_insensitive_duplicate_attribute_keys_rejected(
+        self, client: TestClient, session: Session
+    ):
+        """Duplicate attribute keys differing only in case should be rejected."""
+        pid = _create_project(session)
+
+        response = client.post(
+            f"/api/v1/projects/{pid}/samples/bulk",
+            json={
+                "samples": [
+                    {
+                        "sample_id": "ATTR_CI",
+                        "attributes": [
+                            {"key": "Tissue", "value": "Liver"},
+                            {"key": "tissue", "value": "Heart"},
+                        ],
+                    },
+                ]
+            },
+        )
+        assert response.status_code == 400
+        assert "duplicate" in response.json()["detail"].lower()
+
     def test_bulk_nonexistent_project(
         self, client: TestClient, session: Session
     ):

--- a/tests/api/test_pipeline_entity.py
+++ b/tests/api/test_pipeline_entity.py
@@ -61,6 +61,22 @@ def test_create_pipeline_with_version_and_attributes(client: TestClient):
     assert attr_keys == {"organism", "assay"}
 
 
+def test_create_pipeline_rejects_case_insensitive_duplicate_attributes(
+    client: TestClient,
+):
+    """Duplicate attribute keys differing only in case should be rejected."""
+    body = {
+        "name": "Dup Attr Pipeline",
+        "attributes": [
+            {"key": "Organism", "value": "human"},
+            {"key": "organism", "value": "mouse"},
+        ],
+    }
+    resp = client.post("/api/v1/pipelines", json=body)
+    assert resp.status_code == 400
+    assert "duplicate" in resp.json()["detail"].lower()
+
+
 def test_create_pipeline_with_workflow_ids(client: TestClient, session: Session):
     """Create a pipeline pre-linked to existing workflows."""
     wf1_id = _create_workflow(session, "Step 1 - Trim")

--- a/tests/api/test_pipeline_entity.py
+++ b/tests/api/test_pipeline_entity.py
@@ -64,7 +64,7 @@ def test_create_pipeline_with_version_and_attributes(client: TestClient):
 def test_create_pipeline_rejects_case_insensitive_duplicate_attributes(
     client: TestClient,
 ):
-    """Duplicate attribute keys differing only in case should be rejected."""
+    """Test that creating a pipeline with attribute keys differing only in case returns 400."""
     body = {
         "name": "Dup Attr Pipeline",
         "attributes": [

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -277,7 +277,7 @@ def test_create_project_fails_with_duplicate_attribute(client: TestClient):
 def test_create_project_fails_with_case_insensitive_duplicate_attribute(
     client: TestClient,
 ):
-    """Duplicate keys differing only in case should be rejected."""
+    """Test that creating a project with attribute keys differing only in case returns 400."""
     data = {
         "name": "Test Project",
         "attributes": [
@@ -456,7 +456,7 @@ def test_update_project_with_duplicate_attributes(client: TestClient, session: S
 def test_update_project_with_case_insensitive_duplicate_attributes(
     client: TestClient, session: Session
 ):
-    """Duplicate keys differing only in case should be rejected on PUT."""
+    """Test that PUT update with attribute keys differing only in case returns 400."""
     new_project = Project(name="Test Project")
     new_project.project_id = generate_project_id(session=session)
     new_project.attributes = []
@@ -728,7 +728,7 @@ def test_patch_project_duplicate_attribute_keys(
 def test_patch_project_case_insensitive_duplicate_attribute_keys(
     client: TestClient, session: Session
 ):
-    """PATCH with case-mismatched duplicate keys should be rejected."""
+    """Test that PATCH with attribute keys differing only in case returns 400."""
     new_project = Project(name="Test Project")
     new_project.project_id = generate_project_id(session=session)
     new_project.attributes = []
@@ -752,7 +752,8 @@ def test_patch_project_case_insensitive_duplicate_attribute_keys(
 def test_patch_project_upserts_attribute_case_insensitively(
     client: TestClient, session: Session
 ):
-    """PATCH should match existing attributes case-insensitively (like MySQL collation)."""
+    """Test that PATCH matches existing attributes case-insensitively
+    and updates the value without creating a duplicate."""
     new_project = Project(name="Test Project")
     new_project.project_id = generate_project_id(session=session)
     new_project.attributes = [

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -274,6 +274,22 @@ def test_create_project_fails_with_duplicate_attribute(client: TestClient):
     assert response.status_code == 400
 
 
+def test_create_project_fails_with_case_insensitive_duplicate_attribute(
+    client: TestClient,
+):
+    """Duplicate keys differing only in case should be rejected."""
+    data = {
+        "name": "Test Project",
+        "attributes": [
+            {"key": "Priority", "value": "High"},
+            {"key": "priority", "value": "Low"},
+        ],
+    }
+    response = client.post("/api/v1/projects", json=data)
+    assert response.status_code == 400
+    assert "duplicate" in response.json()["detail"].lower()
+
+
 def test_generate_project_id(session: Session):
     """Test that we can generate a project id"""
     # Generate a project id
@@ -433,6 +449,29 @@ def test_update_project_with_duplicate_attributes(client: TestClient, session: S
     }
     response = client.put(f"/api/v1/projects/{new_project.project_id}", json=update_data)
 
+    assert response.status_code == 400
+    assert "duplicate" in response.json()["detail"].lower()
+
+
+def test_update_project_with_case_insensitive_duplicate_attributes(
+    client: TestClient, session: Session
+):
+    """Duplicate keys differing only in case should be rejected on PUT."""
+    new_project = Project(name="Test Project")
+    new_project.project_id = generate_project_id(session=session)
+    new_project.attributes = []
+    session.add(new_project)
+    session.commit()
+
+    update_data = {
+        "attributes": [
+            {"key": "Priority", "value": "High"},
+            {"key": "priority", "value": "Low"},
+        ]
+    }
+    response = client.put(
+        f"/api/v1/projects/{new_project.project_id}", json=update_data
+    )
     assert response.status_code == 400
     assert "duplicate" in response.json()["detail"].lower()
 
@@ -684,6 +723,59 @@ def test_patch_project_duplicate_attribute_keys(
 
     assert response.status_code == 400
     assert "duplicate" in response.json()["detail"].lower()
+
+
+def test_patch_project_case_insensitive_duplicate_attribute_keys(
+    client: TestClient, session: Session
+):
+    """PATCH with case-mismatched duplicate keys should be rejected."""
+    new_project = Project(name="Test Project")
+    new_project.project_id = generate_project_id(session=session)
+    new_project.attributes = []
+    session.add(new_project)
+    session.commit()
+
+    update_data = {
+        "attributes": [
+            {"key": "Priority", "value": "High"},
+            {"key": "priority", "value": "Low"},
+        ]
+    }
+    response = client.patch(
+        f"/api/v1/projects/{new_project.project_id}",
+        json=update_data,
+    )
+    assert response.status_code == 400
+    assert "duplicate" in response.json()["detail"].lower()
+
+
+def test_patch_project_upserts_attribute_case_insensitively(
+    client: TestClient, session: Session
+):
+    """PATCH should match existing attributes case-insensitively (like MySQL collation)."""
+    new_project = Project(name="Test Project")
+    new_project.project_id = generate_project_id(session=session)
+    new_project.attributes = [
+        ProjectAttribute(key="Department", value="R&D"),
+    ]
+    session.add(new_project)
+    session.commit()
+
+    # Patch with different casing — should update existing, not create duplicate
+    update_data = {
+        "attributes": [
+            {"key": "department", "value": "Engineering"},
+        ]
+    }
+    response = client.patch(
+        f"/api/v1/projects/{new_project.project_id}",
+        json=update_data,
+    )
+    assert response.status_code == 200
+    attrs = response.json()["attributes"]
+    assert len(attrs) == 1
+    assert attrs[0]["key"] == "department"
+    assert attrs[0]["value"] == "Engineering"
 
 
 ###############################################################################

--- a/tests/api/test_sample_upload.py
+++ b/tests/api/test_sample_upload.py
@@ -288,13 +288,9 @@ class TestSampleUploadCaseMismatch:
     def test_reupload_with_case_mismatch_attributes(
         self, client: TestClient, session: Session
     ):
-        """Scenario: existing sample has UPPERCASE attribute keys in DB.
-        User downloads metadata, fills in new samples, re-uploads TSV
-        with lowercase column headers.
-
-        Expected behavior: the upsert should match existing attributes
-        case-insensitively and update the value rather than creating a
-        duplicate row.
+        """Test that re-uploading a TSV with different-cased column headers
+        than existing attributes matches case-insensitively and updates
+        rather than creating duplicates.
         """
         pid = _create_project(session)
 

--- a/tests/api/test_sample_upload.py
+++ b/tests/api/test_sample_upload.py
@@ -269,3 +269,131 @@ class TestSampleUploadErrors:
         response = _upload(client, pid, "", filename="empty.csv")
         assert response.status_code == 400
         assert "empty" in response.json()["detail"].lower()
+
+
+# ===================================================================
+# Case-insensitive attribute key tests
+# ===================================================================
+
+
+class TestSampleUploadCaseMismatch:
+    """Reproduce the autoflush IntegrityError on re-upload with case-
+    mismatched attribute keys.
+
+    On MySQL the case-insensitive unique constraint rejects duplicate
+    INSERTs.  On SQLite the INSERT succeeds, but creates duplicate
+    attribute rows differing only in case — still a bug.
+    """
+
+    def test_reupload_with_case_mismatch_attributes(
+        self, client: TestClient, session: Session
+    ):
+        """Scenario: existing sample has UPPERCASE attribute keys in DB.
+        User downloads metadata, fills in new samples, re-uploads TSV
+        with lowercase column headers.
+
+        Expected behavior: the upsert should match existing attributes
+        case-insensitively and update the value rather than creating a
+        duplicate row.
+        """
+        pid = _create_project(session)
+
+        # Step 1: Create sample with UPPERCASE attribute keys
+        csv_upper = (
+            "SampleID,SAMPLE_NAME,SOURCE,SOURCE_PROJECT,"
+            "SOURCE_ID,EXT_PROJECT_ID,PROJECT_DESC,ASSAY_TYPE,"
+            "ORGANISM,PLATFORM,CAPTURE_METHOD\n"
+            "sample_alpha_R1,"
+            "sample_alpha_R1,"
+            "External Lab A,"
+            "PRJ-0001,"
+            "sample_alpha_R1,"
+            "PRJ-0001,"
+            "Lymphoma_scRNA_study,"
+            "single cell mRNA-Seq,"
+            "Homo sapiens,"
+            "SequencerX 500,"
+            "Droplet Capture\n"
+        )
+        r1 = _upload(client, pid, csv_upper)
+        assert r1.status_code == 201, f"First upload failed: {r1.json()}"
+        assert r1.json()["samples_created"] == 1
+
+        # Verify UPPERCASE keys are in DB
+        sample = session.exec(
+            select(Sample).where(
+                Sample.sample_id == "sample_alpha_R1",
+                Sample.project_id == pid,
+            )
+        ).one()
+        attrs_before = session.exec(
+            select(SampleAttribute).where(
+                SampleAttribute.sample_id == sample.id
+            )
+        ).all()
+        keys_before = {a.key for a in attrs_before}
+        assert "SAMPLE_NAME" in keys_before
+        assert len(attrs_before) == 10  # 10 attribute columns
+
+        # Step 2: Re-upload with lowercase column headers (the user's TSV)
+        # Includes the existing sample + a new sample.
+        csv_lower = (
+            "SampleID,sample_name,source,source_project,"
+            "source_id,ext_project_id,project_desc,assay_type,"
+            "organism,platform,capture_method\n"
+            "sample_alpha_R1,"
+            "sample_alpha_R1,"
+            "External Lab A,"
+            "PRJ-0001,"
+            "sample_alpha_R1,"
+            "PRJ-0001,"
+            "Lymphoma_scRNA_study,"
+            "single cell mRNA-Seq,"
+            "Homo sapiens,"
+            "SequencerX 500,"
+            "Droplet Capture\n"
+            "sample_beta_R1,"
+            "sample_beta_R1,"
+            "External Lab A,"
+            "PRJ-0001,"
+            "sample_beta_R1,"
+            "PRJ-0001,"
+            "Lymphoma_scRNA_study,"
+            "single cell mRNA-Seq,"
+            "Homo sapiens,"
+            "SequencerX 500,"
+            "Droplet Capture\n"
+        )
+        r2 = _upload(client, pid, csv_lower)
+        assert r2.status_code == 201, (
+            f"Re-upload with case-mismatched keys failed: {r2.json()}"
+        )
+
+        # Verify no duplicate attributes (case-insensitive) on the
+        # existing sample.  On MySQL this would have been an
+        # IntegrityError; on SQLite we check for correctness.
+        session.expire_all()
+        attrs_after = session.exec(
+            select(SampleAttribute).where(
+                SampleAttribute.sample_id == sample.id
+            )
+        ).all()
+
+        # Group by lowered key — each key should appear only once
+        key_counts: dict[str, int] = {}
+        for a in attrs_after:
+            lk = a.key.lower()
+            key_counts[lk] = key_counts.get(lk, 0) + 1
+
+        duplicates = {k: v for k, v in key_counts.items() if v > 1}
+        assert not duplicates, (
+            f"Duplicate attributes (case-insensitive) found: {duplicates}. "
+            f"All keys: {[a.key for a in attrs_after]}"
+        )
+
+        # Should still have exactly 10 attributes (not 20)
+        assert len(attrs_after) == 10, (
+            f"Expected 10 attributes, got {len(attrs_after)}: "
+            f"{[a.key for a in attrs_after]}"
+        )
+

--- a/tests/api/test_sample_upload.py
+++ b/tests/api/test_sample_upload.py
@@ -392,4 +392,3 @@ class TestSampleUploadCaseMismatch:
             f"Expected 10 attributes, got {len(attrs_after)}: "
             f"{[a.key for a in attrs_after]}"
         )
-

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -191,9 +191,7 @@ def test_fail_to_add__sample_with_duplicate_attributes(
 def test_fail_to_add_sample_with_case_insensitive_duplicate_attributes(
     client: TestClient, session: Session
 ):
-    """
-    Duplicate keys differing only in case should be rejected.
-    """
+    """Test that adding a sample with attribute keys differing only in case returns 400."""
     new_project = Project(name="Test Project")
     new_project.project_id = generate_project_id(session=session)
     new_project.attributes = []

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -188,6 +188,33 @@ def test_fail_to_add__sample_with_duplicate_attributes(
     assert response.status_code == 400
 
 
+def test_fail_to_add_sample_with_case_insensitive_duplicate_attributes(
+    client: TestClient, session: Session
+):
+    """
+    Duplicate keys differing only in case should be rejected.
+    """
+    new_project = Project(name="Test Project")
+    new_project.project_id = generate_project_id(session=session)
+    new_project.attributes = []
+    session.add(new_project)
+    session.commit()
+
+    sample_data = {
+        "sample_id": "Sample_1",
+        "attributes": [
+            {"key": "Tissue", "value": "Liver"},
+            {"key": "tissue", "value": "Heart"},
+        ],
+    }
+
+    response = client.post(
+        f"/api/v1/projects/{new_project.project_id}/samples", json=sample_data
+    )
+    assert response.status_code == 400
+    assert "duplicate" in response.json()["detail"].lower()
+
+
 def test_fail_to_add_sample_to_project(client: TestClient, session: Session):
     """
     Test that we fail to add a sample to a project when a projecT_id is provided in sample data


### PR DESCRIPTION
The SampleAttribute unique constraint (sample_id, key) is case-insensitive on MySQL but the Python dict lookup used to detect existing attributes was case-sensitive (note: this is also case-sensitive in SQLite, which meant our test env can't reproduce the exact behavior without explicit assertions).

When a user re-uploaded a TSV with differently-cased column headers (e.g. 'samplename_vendor' vs 'SAMPLENAME_VENDOR') for existing samples, the code treated them as new attributes and attempted an INSERT, which MySQL rejected with IntegrityError 1062 and a resulting 500 error to the frontend.

This bugfix PR extracts 6 separate places in the codebase where we were performing duplicate attribute key checking into a single re-used function in api/utils.py, check_duplicate_attribute_keys, which converts to lower first to ensure case-insensitive matching, consistent with MySQL behavior.