### PR TITLE
Use version_num instead of version_id for simplicity

### DIFF
--- a/api/workflow/models.py
+++ b/api/workflow/models.py
@@ -186,7 +186,7 @@ class WorkflowVersionPublic(SQLModel):
 
 class WorkflowVersionAliasSet(SQLModel):
     """Body for PUT /workflows/{id}/aliases/{alias}."""
-    workflow_version_id: uuid.UUID
+    version_num: int
 
 
 class WorkflowVersionAliasPublic(SQLModel):

--- a/api/workflow/routes.py
+++ b/api/workflow/routes.py
@@ -143,20 +143,18 @@ def get_workflow_versions(
 
 
 @router.get(
-    "/{workflow_id}/versions/{version_id}",
+    "/{workflow_id}/versions/{version_num}",
     response_model=WorkflowVersionPublic,
     tags=["Workflow Endpoints"],
 )
-def get_workflow_version_by_id(
+def get_workflow_version(
     session: SessionDep,
     workflow_id: str,
-    version_id: str,
+    version_num: int,
 ) -> WorkflowVersionPublic:
     """Get a specific workflow version."""
-    # Verify workflow exists first
-    services.get_workflow_by_id(session, workflow_id)
-    version = services.get_workflow_version_by_id(
-        session=session, version_id=version_id,
+    version = services.get_workflow_version_by_num(
+        session=session, workflow_id=workflow_id, version_num=version_num,
     )
     return services.workflow_version_to_public(version)
 
@@ -284,7 +282,7 @@ def get_workflow_deployments_for_workflow(
 # ---------------------------------------------------------------------------
 
 @router.post(
-    "/{workflow_id}/versions/{version_id}/deployments",
+    "/{workflow_id}/versions/{version_num}/deployments",
     response_model=WorkflowDeploymentPublic,
     tags=["Workflow Endpoints"],
     status_code=status.HTTP_201_CREATED,
@@ -293,14 +291,14 @@ def create_workflow_deployment(
     session: SessionDep,
     user: CurrentUser,
     workflow_id: str,
-    version_id: str,
+    version_num: int,
     deployment_in: WorkflowDeploymentCreate,
 ) -> WorkflowDeploymentPublic:
     """Deploy a workflow version on a specific platform."""
     dep = services.create_workflow_deployment(
         session=session,
         workflow_id=workflow_id,
-        version_id=version_id,
+        version_num=version_num,
         deployment_in=deployment_in,
         created_by=user.username,
     )
@@ -315,14 +313,14 @@ def create_workflow_deployment(
 
 
 @router.get(
-    "/{workflow_id}/versions/{version_id}/deployments",
+    "/{workflow_id}/versions/{version_num}/deployments",
     response_model=List[WorkflowDeploymentPublic],
     tags=["Workflow Endpoints"],
 )
 def get_workflow_deployments(
     session: SessionDep,
     workflow_id: str,
-    version_id: str,
+    version_num: int,
     engine: str | None = Query(
         None,
         description="Filter by engine/platform name",
@@ -332,7 +330,7 @@ def get_workflow_deployments(
     deps = services.get_workflow_deployments(
         session=session,
         workflow_id=workflow_id,
-        version_id=version_id,
+        version_num=version_num,
         engine=engine,
     )
     return [
@@ -349,7 +347,7 @@ def get_workflow_deployments(
 
 
 @router.delete(
-    "/{workflow_id}/versions/{version_id}"
+    "/{workflow_id}/versions/{version_num}"
     "/deployments/{deployment_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["Workflow Endpoints"],
@@ -357,13 +355,13 @@ def get_workflow_deployments(
 def delete_workflow_deployment(
     session: SessionDep,
     workflow_id: str,
-    version_id: str,
+    version_num: int,
     deployment_id: str,
 ) -> None:
     """Remove a platform deployment."""
     services.delete_workflow_deployment(
         session=session,
         workflow_id=workflow_id,
-        version_id=version_id,
+        version_num=version_num,
         deployment_id=deployment_id,
     )

--- a/api/workflow/services.py
+++ b/api/workflow/services.py
@@ -285,21 +285,23 @@ def get_workflow_versions(
     return versions
 
 
-def get_workflow_version_by_id(
-    session: Session, version_id: str,
+def get_workflow_version_by_num(
+    session: Session, workflow_id: str, version_num: int,
 ) -> WorkflowVersion:
-    """Get a single workflow version by its UUID."""
-    ver_uuid = _parse_uuid(version_id, "version_id")
+    """Get a workflow version by its (workflow_id, version) composite key."""
+    workflow = get_workflow_by_id(session, workflow_id)
     version = session.exec(
-        select(WorkflowVersion)
-        .where(WorkflowVersion.id == ver_uuid)
+        select(WorkflowVersion).where(
+            WorkflowVersion.workflow_id == workflow.id,
+            WorkflowVersion.version == version_num,
+        )
     ).first()
     if not version:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=(
-                f"Workflow version with id "
-                f"'{version_id}' not found."
+                f"Version {version_num} not found "
+                f"for workflow '{workflow_id}'."
             ),
         )
     return version
@@ -354,29 +356,15 @@ def set_workflow_version_alias(
     created_by: str,
 ) -> WorkflowVersionAlias:
     """Set or move an alias to a specific workflow version."""
-    workflow = get_workflow_by_id(session, workflow_id)
-
     # Verify the target version exists and belongs to this workflow
-    version = session.exec(
-        select(WorkflowVersion).where(
-            WorkflowVersion.id == alias_in.workflow_version_id,
-            WorkflowVersion.workflow_id == workflow.id,
-        )
-    ).first()
-    if not version:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=(
-                f"Workflow version "
-                f"'{alias_in.workflow_version_id}' not found "
-                f"for workflow '{workflow_id}'."
-            ),
-        )
+    version = get_workflow_version_by_num(
+        session, workflow_id, alias_in.version_num,
+    )
 
     # Upsert — replace existing alias or create new one
     existing = session.exec(
         select(WorkflowVersionAlias).where(
-            WorkflowVersionAlias.workflow_id == workflow.id,
+            WorkflowVersionAlias.workflow_id == version.workflow_id,
             WorkflowVersionAlias.alias == alias,
         )
     ).first()
@@ -390,7 +378,7 @@ def set_workflow_version_alias(
         return existing
 
     alias_record = WorkflowVersionAlias(
-        workflow_id=workflow.id,
+        workflow_id=version.workflow_id,
         alias=alias,
         workflow_version_id=version.id,
         created_by=created_by,
@@ -464,35 +452,18 @@ def alias_to_public(
 def create_workflow_deployment(
     session: Session,
     workflow_id: str,
-    version_id: str,
+    version_num: int,
     deployment_in: WorkflowDeploymentCreate,
     created_by: str,
 ) -> WorkflowDeployment:
     """Deploy a workflow version on a specific platform."""
-    # Verify workflow exists
-    workflow = get_workflow_by_id(session, workflow_id)
-
     # Verify version exists and belongs to this workflow
-    ver_uuid = _parse_uuid(version_id, "version_id")
-    version = session.exec(
-        select(WorkflowVersion).where(
-            WorkflowVersion.id == ver_uuid,
-            WorkflowVersion.workflow_id == workflow.id,
-        )
-    ).first()
-    if not version:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=(
-                f"Version '{version_id}' not found "
-                f"for workflow '{workflow_id}'."
-            ),
-        )
+    version = get_workflow_version_by_num(session, workflow_id, version_num)
 
     # Verify engine is a registered platform
     _validate_engine(session, deployment_in.engine)
 
-    # Check for duplicate (version_id, engine)
+    # Check for duplicate (version, engine)
     existing = session.exec(
         select(WorkflowDeployment).where(
             WorkflowDeployment.workflow_version_id == version.id,
@@ -503,7 +474,7 @@ def create_workflow_deployment(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
-                f"Version '{version_id}' is already deployed "
+                f"Version {version_num} is already deployed "
                 f"on engine '{deployment_in.engine}'."
             ),
         )
@@ -524,26 +495,11 @@ def create_workflow_deployment(
 def get_workflow_deployments(
     session: Session,
     workflow_id: str,
-    version_id: str,
+    version_num: int,
     engine: str | None = None,
 ) -> list[WorkflowDeployment]:
     """List platform deployments for a workflow version."""
-    workflow = get_workflow_by_id(session, workflow_id)
-    ver_uuid = _parse_uuid(version_id, "version_id")
-    version = session.exec(
-        select(WorkflowVersion).where(
-            WorkflowVersion.id == ver_uuid,
-            WorkflowVersion.workflow_id == workflow.id,
-        )
-    ).first()
-    if not version:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=(
-                f"Version '{version_id}' not found "
-                f"for workflow '{workflow_id}'."
-            ),
-        )
+    version = get_workflow_version_by_num(session, workflow_id, version_num)
     stmt = select(WorkflowDeployment).where(
         WorkflowDeployment.workflow_version_id == version.id,
     )
@@ -606,26 +562,11 @@ def get_workflow_deployments_for_workflow(
 def delete_workflow_deployment(
     session: Session,
     workflow_id: str,
-    version_id: str,
+    version_num: int,
     deployment_id: str,
 ) -> None:
     """Remove a workflow platform deployment."""
-    workflow = get_workflow_by_id(session, workflow_id)
-    ver_uuid = _parse_uuid(version_id, "version_id")
-    version = session.exec(
-        select(WorkflowVersion).where(
-            WorkflowVersion.id == ver_uuid,
-            WorkflowVersion.workflow_id == workflow.id,
-        )
-    ).first()
-    if not version:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=(
-                f"Version '{version_id}' not found "
-                f"for workflow '{workflow_id}'."
-            ),
-        )
+    version = get_workflow_version_by_num(session, workflow_id, version_num)
     dep_uuid = _parse_uuid(deployment_id, "deployment_id")
     deployment = session.exec(
         select(WorkflowDeployment).where(
@@ -638,7 +579,7 @@ def delete_workflow_deployment(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=(
                 f"Deployment '{deployment_id}' not found "
-                f"for version '{version_id}'."
+                f"for version {version_num}."
             ),
         )
     session.delete(deployment)

--- a/tests/api/test_workflow_aliases.py
+++ b/tests/api/test_workflow_aliases.py
@@ -13,8 +13,8 @@ from api.workflow.models import Workflow, WorkflowVersion
 def _create_workflow_and_version(
     session: Session,
     version: int = 1,
-) -> tuple[str, str]:
-    """Insert a workflow + version; return (wf_id, version_id)."""
+) -> tuple[str, str, int]:
+    """Insert a workflow + version; return (wf_id, version_uuid, version_num)."""
     wf = Workflow(name="Alias Test WF", created_by="testuser")
     session.add(wf)
     session.flush()
@@ -28,7 +28,7 @@ def _create_workflow_and_version(
     session.commit()
     session.refresh(wf)
     session.refresh(ver)
-    return str(wf.id), str(ver.id)
+    return str(wf.id), str(ver.id), ver.version
 
 
 # ---------------------------------------------------------------------------
@@ -37,9 +37,9 @@ def _create_workflow_and_version(
 
 def test_set_alias(client: TestClient, session: Session):
     """Set the production alias."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
-    body = {"workflow_version_id": ver_id}
+    body = {"version_num": ver_num}
     resp = client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
         json=body,
@@ -58,11 +58,11 @@ def test_set_alias_development(
     client: TestClient, session: Session,
 ):
     """Set the development alias."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     resp = client.put(
         f"/api/v1/workflows/{wf_id}/aliases/development",
-        json={"workflow_version_id": ver_id},
+        json={"version_num": ver_num},
     )
     assert resp.status_code == 200
     assert resp.json()["alias"] == "development"
@@ -72,11 +72,11 @@ def test_set_alias_custom_value(
     client: TestClient, session: Session,
 ):
     """Any free-text alias value is accepted."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     resp = client.put(
         f"/api/v1/workflows/{wf_id}/aliases/staging",
-        json={"workflow_version_id": ver_id},
+        json={"version_num": ver_num},
     )
     assert resp.status_code == 200
     assert resp.json()["alias"] == "staging"
@@ -104,13 +104,11 @@ def test_move_alias_to_different_version(
     session.refresh(v2)
 
     wf_id = str(wf.id)
-    v1_id = str(v1.id)
-    v2_id = str(v2.id)
 
     # Set to v1
     resp1 = client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
-        json={"workflow_version_id": v1_id},
+        json={"version_num": 1},
     )
     assert resp1.status_code == 200
     assert resp1.json()["version"] == 1
@@ -118,7 +116,7 @@ def test_move_alias_to_different_version(
     # Move to v2
     resp2 = client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
-        json={"workflow_version_id": v2_id},
+        json={"version_num": 2},
     )
     assert resp2.status_code == 200
     assert resp2.json()["version"] == 2
@@ -133,10 +131,9 @@ def test_set_alias_version_not_found(
     session.commit()
     session.refresh(wf)
 
-    fake_ver = "00000000-0000-0000-0000-000000000000"
     resp = client.put(
         f"/api/v1/workflows/{wf.id}/aliases/production",
-        json={"workflow_version_id": fake_ver},
+        json={"version_num": 99},
     )
     assert resp.status_code == 404
 
@@ -165,15 +162,15 @@ def test_get_aliases_multiple(
     client: TestClient, session: Session,
 ):
     """List aliases after setting both production and development."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
-        json={"workflow_version_id": ver_id},
+        json={"version_num": ver_num},
     )
     client.put(
         f"/api/v1/workflows/{wf_id}/aliases/development",
-        json={"workflow_version_id": ver_id},
+        json={"version_num": ver_num},
     )
 
     resp = client.get(
@@ -192,11 +189,11 @@ def test_get_aliases_multiple(
 
 def test_delete_alias(client: TestClient, session: Session):
     """Delete an alias returns 204."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
-        json={"workflow_version_id": ver_id},
+        json={"version_num": ver_num},
     )
 
     del_resp = client.delete(
@@ -234,15 +231,15 @@ def test_get_aliases_filter_by_alias(
     client: TestClient, session: Session,
 ):
     """Filter aliases by alias name returns only that alias."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
-        json={"workflow_version_id": ver_id},
+        json={"version_num": ver_num},
     )
     client.put(
         f"/api/v1/workflows/{wf_id}/aliases/development",
-        json={"workflow_version_id": ver_id},
+        json={"version_num": ver_num},
     )
 
     resp = client.get(
@@ -259,11 +256,11 @@ def test_get_aliases_filter_no_match(
     client: TestClient, session: Session,
 ):
     """Filter by alias that isn't set returns empty list."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
-        json={"workflow_version_id": ver_id},
+        json={"version_num": ver_num},
     )
 
     resp = client.get(
@@ -282,11 +279,11 @@ def test_workflow_public_includes_aliases(
     client: TestClient, session: Session,
 ):
     """GET /workflows/{id} includes nested alias data."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
-        json={"workflow_version_id": ver_id},
+        json={"version_num": ver_num},
     )
 
     resp = client.get(f"/api/v1/workflows/{wf_id}")

--- a/tests/api/test_workflow_deployments.py
+++ b/tests/api/test_workflow_deployments.py
@@ -13,8 +13,8 @@ from api.workflow.models import Workflow, WorkflowVersion
 
 def _create_workflow_and_version(
     session: Session,
-) -> tuple[str, str]:
-    """Insert a workflow + version; return (wf_id, version_id)."""
+) -> tuple[str, str, int]:
+    """Insert a workflow + version; return (wf_id, version_uuid, version_num)."""
     wf = Workflow(
         name="WDL Alignment",
         created_by="testuser",
@@ -31,7 +31,7 @@ def _create_workflow_and_version(
     session.commit()
     session.refresh(wf)
     session.refresh(ver)
-    return str(wf.id), str(ver.id)
+    return str(wf.id), str(ver.id), ver.version
 
 
 def _seed_platforms(session: Session) -> None:
@@ -42,7 +42,7 @@ def _seed_platforms(session: Session) -> None:
 
 
 # ---------------------------------------------------------------------------
-# POST /workflows/{id}/versions/{vid}/deployments
+# POST /workflows/{id}/versions/{version_num}/deployments
 # ---------------------------------------------------------------------------
 
 def test_create_deployment(
@@ -50,14 +50,14 @@ def test_create_deployment(
 ):
     """Deploy a workflow version on a platform engine."""
     _seed_platforms(session)
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     body = {
         "engine": "Arvados",
         "external_id": "arvados-wf-abc123",
     }
     resp = client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json=body,
     )
@@ -77,14 +77,14 @@ def test_create_deployment_minimal(
 ):
     """Only engine and external_id are required."""
     _seed_platforms(session)
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     body = {
         "engine": "SevenBridges",
         "external_id": "sb-app-xyz",
     }
     resp = client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json=body,
     )
@@ -95,13 +95,13 @@ def test_create_deployment_minimal(
 def test_create_deployment_duplicate_engine_conflict(
     client: TestClient, session: Session,
 ):
-    """Duplicate (version_id, engine) pair returns 409."""
+    """Duplicate (version_num, engine) pair returns 409."""
     _seed_platforms(session)
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     body = {"engine": "Arvados", "external_id": "arv-1"}
     resp1 = client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json=body,
     )
@@ -109,7 +109,7 @@ def test_create_deployment_duplicate_engine_conflict(
 
     body2 = {"engine": "Arvados", "external_id": "arv-2"}
     resp2 = client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json=body2,
     )
@@ -126,10 +126,9 @@ def test_create_deployment_version_not_found(
     session.commit()
     session.refresh(wf)
 
-    fake_ver = "00000000-0000-0000-0000-000000000000"
     body = {"engine": "Arvados", "external_id": "x"}
     resp = client.post(
-        f"/api/v1/workflows/{wf.id}/versions/{fake_ver}"
+        f"/api/v1/workflows/{wf.id}/versions/99"
         f"/deployments",
         json=body,
     )
@@ -140,11 +139,11 @@ def test_create_deployment_invalid_engine(
     client: TestClient, session: Session,
 ):
     """Deployment with an unregistered engine returns 400."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     body = {"engine": "UnknownPlatform", "external_id": "x"}
     resp = client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json=body,
     )
@@ -153,16 +152,16 @@ def test_create_deployment_invalid_engine(
 
 
 # ---------------------------------------------------------------------------
-# GET /workflows/{id}/versions/{vid}/deployments
+# GET /workflows/{id}/versions/{version_num}/deployments
 # ---------------------------------------------------------------------------
 
 def test_get_deployments_empty(
     client: TestClient, session: Session,
 ):
     """List deployments for a version with none."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
     resp = client.get(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
     )
     assert resp.status_code == 200
@@ -174,15 +173,15 @@ def test_get_deployments_multiple(
 ):
     """List deployments after adding two engines."""
     _seed_platforms(session)
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json={"engine": "Arvados", "external_id": "arv-1"},
     )
     client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json={
             "engine": "SevenBridges",
@@ -191,7 +190,7 @@ def test_get_deployments_multiple(
     )
 
     resp = client.get(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
     )
     assert resp.status_code == 200
@@ -210,24 +209,24 @@ def test_delete_deployment(
 ):
     """Delete a deployment returns 204 and it's gone."""
     _seed_platforms(session)
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     create_resp = client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json={"engine": "Arvados", "external_id": "arv-1"},
     )
     dep_id = create_resp.json()["id"]
 
     del_resp = client.delete(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments/{dep_id}",
     )
     assert del_resp.status_code == 204
 
     # Verify it's gone
     list_resp = client.get(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
     )
     assert list_resp.json() == []
@@ -237,18 +236,18 @@ def test_delete_deployment_not_found(
     client: TestClient, session: Session,
 ):
     """Deleting a non-existent deployment returns 404."""
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
     fake_dep = "00000000-0000-0000-0000-000000000000"
 
     resp = client.delete(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments/{fake_dep}",
     )
     assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------
-# GET .../versions/{vid}/deployments?engine=
+# GET .../versions/{version_num}/deployments?engine=
 # ---------------------------------------------------------------------------
 
 def test_get_deployments_filter_by_engine(
@@ -256,15 +255,15 @@ def test_get_deployments_filter_by_engine(
 ):
     """Filter version-level deployments by engine."""
     _seed_platforms(session)
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json={"engine": "Arvados", "external_id": "arv-1"},
     )
     client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json={
             "engine": "SevenBridges",
@@ -273,7 +272,7 @@ def test_get_deployments_filter_by_engine(
     )
 
     resp = client.get(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments?engine=Arvados",
     )
     assert resp.status_code == 200
@@ -287,16 +286,16 @@ def test_get_deployments_filter_engine_no_match(
 ):
     """Engine filter returns empty list when no match."""
     _seed_platforms(session)
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json={"engine": "Arvados", "external_id": "arv-1"},
     )
 
     resp = client.get(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments?engine=SevenBridges",
     )
     assert resp.status_code == 200
@@ -312,16 +311,16 @@ def test_version_public_includes_deployments(
 ):
     """GET version includes nested deployment data."""
     _seed_platforms(session)
-    wf_id, ver_id = _create_workflow_and_version(session)
+    wf_id, ver_id, ver_num = _create_workflow_and_version(session)
 
     client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}"
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}"
         f"/deployments",
         json={"engine": "Arvados", "external_id": "arv-1"},
     )
 
     resp = client.get(
-        f"/api/v1/workflows/{wf_id}/versions/{ver_id}",
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}",
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -335,11 +334,11 @@ def test_version_public_includes_deployments(
 
 def _create_two_versions_with_deps(
     client: TestClient, session: Session,
-) -> tuple[str, str, str]:
+) -> tuple[str, int, int]:
     """Seed workflow with 2 versions, each deployed on Arvados.
 
     Also deploys v1 on SevenBridges.
-    Returns (wf_id, v1_id, v2_id).
+    Returns (wf_id, v1_num, v2_num).
     """
     _seed_platforms(session)
     wf = Workflow(name="Multi-Ver WF", created_by="testuser")
@@ -358,16 +357,16 @@ def _create_two_versions_with_deps(
     session.refresh(wf)
     session.refresh(v1)
     session.refresh(v2)
-    wf_id, v1_id, v2_id = str(wf.id), str(v1.id), str(v2.id)
+    wf_id = str(wf.id)
 
     # v1: Arvados + SevenBridges
     client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{v1_id}"
+        f"/api/v1/workflows/{wf_id}/versions/1"
         f"/deployments",
         json={"engine": "Arvados", "external_id": "arv-v1"},
     )
     client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{v1_id}"
+        f"/api/v1/workflows/{wf_id}/versions/1"
         f"/deployments",
         json={
             "engine": "SevenBridges",
@@ -376,11 +375,11 @@ def _create_two_versions_with_deps(
     )
     # v2: Arvados only
     client.post(
-        f"/api/v1/workflows/{wf_id}/versions/{v2_id}"
+        f"/api/v1/workflows/{wf_id}/versions/2"
         f"/deployments",
         json={"engine": "Arvados", "external_id": "arv-v2"},
     )
-    return wf_id, v1_id, v2_id
+    return wf_id, 1, 2
 
 
 def test_workflow_deployments_no_filter(
@@ -419,13 +418,13 @@ def test_workflow_deployments_filter_alias(
     client: TestClient, session: Session,
 ):
     """Alias filter resolves to a version and returns its deps."""
-    wf_id, v1_id, _ = _create_two_versions_with_deps(
+    wf_id, v1_num, _ = _create_two_versions_with_deps(
         client, session,
     )
     # Set production → v1
     client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
-        json={"workflow_version_id": v1_id},
+        json={"version_num": v1_num},
     )
 
     resp = client.get(
@@ -443,12 +442,12 @@ def test_workflow_deployments_filter_alias_and_engine(
     client: TestClient, session: Session,
 ):
     """Alias + engine yields at most one deployment."""
-    wf_id, v1_id, _ = _create_two_versions_with_deps(
+    wf_id, v1_num, _ = _create_two_versions_with_deps(
         client, session,
     )
     client.put(
         f"/api/v1/workflows/{wf_id}/aliases/production",
-        json={"workflow_version_id": v1_id},
+        json={"version_num": v1_num},
     )
 
     resp = client.get(

--- a/tests/api/test_workflow_versions.py
+++ b/tests/api/test_workflow_versions.py
@@ -132,13 +132,13 @@ def test_get_versions_multiple(
 
 
 # ---------------------------------------------------------------------------
-# GET /workflows/{id}/versions/{version_id}
+# GET /workflows/{id}/versions/{version_num}
 # ---------------------------------------------------------------------------
 
-def test_get_version_by_id(
+def test_get_version_by_num(
     client: TestClient, session: Session,
 ):
-    """Fetch a single version by its ID."""
+    """Fetch a single version by its version number."""
     wf_id = _create_workflow(session)
 
     create_resp = client.post(
@@ -147,15 +147,28 @@ def test_get_version_by_id(
             "definition_uri": "s3://bucket/v1.wdl",
         },
     )
+    assert create_resp.status_code == 201
     version_id = create_resp.json()["id"]
 
     resp = client.get(
-        f"/api/v1/workflows/{wf_id}/versions/{version_id}",
+        f"/api/v1/workflows/{wf_id}/versions/1",
     )
     assert resp.status_code == 200
     data = resp.json()
     assert data["id"] == version_id
     assert data["version"] == 1
+
+
+def test_get_version_by_num_not_found(
+    client: TestClient, session: Session,
+):
+    """Fetch a non-existent version number returns 404."""
+    wf_id = _create_workflow(session)
+
+    resp = client.get(
+        f"/api/v1/workflows/{wf_id}/versions/99",
+    )
+    assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The UniqueConstraint("workflow_id", "version") on the WorkflowVersion table guarantees that (workflow_id, version_num) is a valid composite key. Since all the affected routes already have workflow_id in the path, using version_num: int instead of version_id: str (UUID) is fully supported by the data model and produces a more user-friendly API.