### PR TITLE
Bugfix/post project search response model

### DIFF
--- a/api/project/routes.py
+++ b/api/project/routes.py
@@ -117,9 +117,8 @@ def search_projects(
 
 @router.post(
     "/search",
-    status_code=status.HTTP_201_CREATED,
+    status_code=status.HTTP_200_OK,
     tags=["Project Endpoints"],
-    response_model=ProjectsPublic,
 )
 def reindex_projects(
     session: SessionDep,
@@ -129,7 +128,7 @@ def reindex_projects(
     Reindex projects in database with OpenSearch
     """
     services.reindex_projects(session, client)
-    return 'OK'
+    return {"message": "OK"}
 
 ###############################################################################
 # Project Endpoints /api/v1/projects/{project_id}

--- a/api/runs/models.py
+++ b/api/runs/models.py
@@ -48,6 +48,7 @@ class SequencingRun(SQLModel, table=True):
         "flowcell_id",  # We discovered flowcell may not be in the run id
         "experiment_name",
         "run_folder_uri",
+        "run_date"
     ]
 
     id: uuid.UUID | None = Field(default_factory=uuid.uuid4, primary_key=True)

--- a/api/runs/models.py
+++ b/api/runs/models.py
@@ -48,7 +48,8 @@ class SequencingRun(SQLModel, table=True):
         "flowcell_id",  # We discovered flowcell may not be in the run id
         "experiment_name",
         "run_folder_uri",
-        "run_date"
+        "run_date",
+        "run_time"
     ]
 
     id: uuid.UUID | None = Field(default_factory=uuid.uuid4, primary_key=True)

--- a/api/runs/routes.py
+++ b/api/runs/routes.py
@@ -140,7 +140,7 @@ def search_runs(
 
 @router.post(
     "/search",
-    status_code=status.HTTP_201_CREATED,
+    status_code=status.HTTP_200_OK,
     tags=["Run Endpoints"],
 )
 def reindex_runs(
@@ -151,7 +151,7 @@ def reindex_runs(
     Reindex runs in database with OpenSearch
     """
     services.reindex_runs(session, client)
-    return 'OK'
+    return {"message": "OK"}
 
 ###############################################################################
 # Runs Endpoints /api/v1/runs/demultiplex


### PR DESCRIPTION
This PR fixes two bugs:

1.  The POST /api/v1/{projects/runs}/search response did not meet pydantic requirements - not sure why this wasn't picked up before.
2. The SequenceRun model needed run_date and run_time as __searchable__ to support sorting for the front-end.

