### PR TITLE
return only latest file versions

### DIFF
--- a/api/project/routes.py
+++ b/api/project/routes.py
@@ -339,6 +339,14 @@ def get_project_samples(
     include: TypingList[str] | None = Query(
         None, description="Include related data: files"
     ),
+    file_versions: Literal["latest", "all"] = Query(
+        "latest",
+        description=(
+            "When include=files, controls file version behaviour. "
+            "'latest' (default) returns only the newest version per URI; "
+            "'all' returns every version."
+        ),
+    ),
 ) -> SamplesWithFilesPublic | SamplesPublic:
     """
     Returns a list of samples for a project.
@@ -346,6 +354,9 @@ def get_project_samples(
     Pagination is offset-based: ``skip`` is the number of records to skip
     and ``limit`` caps the page size. Pass ``?include=files`` to eagerly
     load file metadata for each sample.
+
+    By default only the latest version of each file (by URI) is returned.
+    Pass ``?file_versions=all`` to include all versions.
     """
     return services.get_project_samples(
         session=session,
@@ -355,6 +366,7 @@ def get_project_samples(
         sort_by=sort_by,
         sort_order=sort_order,
         include=include,
+        file_versions=file_versions,
     )
 
 

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -749,6 +749,42 @@ def add_sample_to_project(
     return sample
 
 
+def _deduplicate_files_by_uri(
+    file_samples: list,
+) -> list:
+    """
+    Given a list of FileSample associations, group by File.uri and keep only
+    the file with the latest ``created_on`` per URI.
+
+    Args:
+        file_samples: List of FileSample ORM objects (with .file eagerly loaded)
+
+    Returns:
+        List of SampleFilePublic instances (one per unique URI, latest version)
+    """
+    uri_to_best: dict[str, tuple] = {}  # uri -> (created_on, FileSample)
+
+    for fs in file_samples:
+        file = fs.file
+        uri = file.uri
+        created = file.created_on
+
+        if uri not in uri_to_best or created > uri_to_best[uri][0]:
+            uri_to_best[uri] = (created, fs)
+
+    result = []
+    for _uri, (_created, fs) in uri_to_best.items():
+        file = fs.file
+        tags_dict = {t.key: t.value for t in (file.tags or [])}
+        result.append(SampleFilePublic(
+            uri=file.uri,
+            tags=tags_dict or None,
+            created_on=file.created_on,
+        ))
+
+    return result
+
+
 def get_project_samples(
     *,
     session: Session,
@@ -758,6 +794,7 @@ def get_project_samples(
     sort_by: str,
     sort_order: Literal["asc", "desc"],
     include: list[str] | None = None,
+    file_versions: str = "latest",
 ) -> SamplesPublic | SamplesWithFilesPublic:
     """
     Get a paginated list of samples for a specific project.
@@ -770,6 +807,8 @@ def get_project_samples(
         sort_by: Column name to sort by
         sort_order: Sort direction ('asc' or 'desc')
         include: Optional list of related data to include (e.g. ``["files"]``)
+        file_versions: ``"latest"`` (default) returns only the newest file per
+            URI; ``"all"`` returns every version.
 
     Returns:
         SamplesPublic or SamplesWithFilesPublic depending on *include*
@@ -823,11 +862,20 @@ def get_project_samples(
     if include_files:
         public_samples = []
         for sample in samples:
-            files = []
-            for fs in sample.file_samples or []:
-                file = fs.file
-                tags_dict = {t.key: t.value for t in (file.tags or [])}
-                files.append(SampleFilePublic(uri=file.uri, tags=tags_dict or None))
+            if file_versions == "latest":
+                # Deduplicate: keep only the newest version per URI
+                files = _deduplicate_files_by_uri(sample.file_samples or [])
+            else:
+                # Return all versions
+                files = []
+                for fs in sample.file_samples or []:
+                    file = fs.file
+                    tags_dict = {t.key: t.value for t in (file.tags or [])}
+                    files.append(SampleFilePublic(
+                        uri=file.uri,
+                        tags=tags_dict or None,
+                        created_on=file.created_on,
+                    ))
             public_samples.append(
                 SampleWithFilesPublic(
                     sample_id=sample.sample_id,

--- a/api/samples/models.py
+++ b/api/samples/models.py
@@ -91,6 +91,7 @@ class SampleFilePublic(SQLModel):
     """Compact file representation for sample responses."""
     uri: str
     tags: dict[str, str] | None = None  # Flattened from List[FileTag]
+    created_on: datetime  # File version timestamp
 
 
 class SampleWithFilesPublic(SamplePublic):

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -617,7 +617,7 @@ def test_get_samples_file_versions_latest_deduplicates(
 ):
     """With file_versions=latest (default), only the newest version of each
     URI should be returned per sample."""
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timezone
 
     project = _seed_project(session)
     sample = _seed_sample(session, project, "SampleDedupLatest")

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -605,3 +605,184 @@ def test_get_samples_include_files_mixed_samples(
     assert items["SampleWithFiles"]["files"] is not None
     assert len(items["SampleWithFiles"]["files"]) == 1
     assert items["SampleWithNoFiles"]["files"] is None
+
+
+# ---------------------------------------------------------------------------
+# file_versions deduplication tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_samples_file_versions_latest_deduplicates(
+    client: TestClient, session: Session
+):
+    """With file_versions=latest (default), only the newest version of each
+    URI should be returned per sample."""
+    from datetime import datetime, timezone, timedelta
+
+    project = _seed_project(session)
+    sample = _seed_sample(session, project, "SampleDedupLatest")
+
+    uri = "s3://bucket/P-1234/SampleDedupLatest_R1.fastq.gz"
+
+    # Create older version
+    older_file = File(
+        uri=uri,
+        created_on=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    session.add(older_file)
+    session.flush()
+    session.add(FileSample(file_id=older_file.id, sample_id=sample.id))
+    session.add(FileTag(file_id=older_file.id, key="mate", value="R1"))
+    session.add(FileTag(file_id=older_file.id, key="version", value="old"))
+
+    # Create newer version (same URI, later timestamp)
+    newer_file = File(
+        uri=uri,
+        created_on=datetime(2024, 6, 15, tzinfo=timezone.utc),
+    )
+    session.add(newer_file)
+    session.flush()
+    session.add(FileSample(file_id=newer_file.id, sample_id=sample.id))
+    session.add(FileTag(file_id=newer_file.id, key="mate", value="R1"))
+    session.add(FileTag(file_id=newer_file.id, key="version", value="new"))
+
+    session.commit()
+
+    # Default (file_versions=latest) — should return only 1 file
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"include": "files"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 1
+
+    files = data[0]["files"]
+    assert files is not None
+    assert len(files) == 1
+    assert files[0]["uri"] == uri
+    # Should be the newer version's tags
+    assert files[0]["tags"]["version"] == "new"
+    # Should include created_on from the newer version
+    assert "created_on" in files[0]
+    assert files[0]["created_on"] == "2024-06-15T00:00:00Z"
+
+
+def test_get_samples_file_versions_all_returns_all(
+    client: TestClient, session: Session
+):
+    """With file_versions=all, all versions of each URI should be returned."""
+    from datetime import datetime, timezone
+
+    project = _seed_project(session)
+    sample = _seed_sample(session, project, "SampleDedupAll")
+
+    uri = "s3://bucket/P-1234/SampleDedupAll_R1.fastq.gz"
+
+    # Create older version
+    older_file = File(
+        uri=uri,
+        created_on=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    session.add(older_file)
+    session.flush()
+    session.add(FileSample(file_id=older_file.id, sample_id=sample.id))
+    session.add(FileTag(file_id=older_file.id, key="mate", value="R1"))
+
+    # Create newer version
+    newer_file = File(
+        uri=uri,
+        created_on=datetime(2024, 6, 15, tzinfo=timezone.utc),
+    )
+    session.add(newer_file)
+    session.flush()
+    session.add(FileSample(file_id=newer_file.id, sample_id=sample.id))
+    session.add(FileTag(file_id=newer_file.id, key="mate", value="R1"))
+
+    session.commit()
+
+    # file_versions=all — should return both versions
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"include": "files", "file_versions": "all"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 1
+
+    files = data[0]["files"]
+    assert files is not None
+    assert len(files) == 2
+    # Both should have the same URI
+    assert all(f["uri"] == uri for f in files)
+
+
+def test_get_samples_file_versions_latest_distinct_uris_preserved(
+    client: TestClient, session: Session
+):
+    """Deduplication only collapses same-URI files; distinct URIs are kept."""
+    from datetime import datetime, timezone
+
+    project = _seed_project(session)
+    sample = _seed_sample(session, project, "SampleDistinctURIs")
+
+    uri_r1 = "s3://bucket/P-1234/SampleDistinctURIs_R1.fastq.gz"
+    uri_r2 = "s3://bucket/P-1234/SampleDistinctURIs_R2.fastq.gz"
+
+    # R1 file (two versions)
+    f1_old = File(uri=uri_r1, created_on=datetime(2024, 1, 1, tzinfo=timezone.utc))
+    session.add(f1_old)
+    session.flush()
+    session.add(FileSample(file_id=f1_old.id, sample_id=sample.id))
+    session.add(FileTag(file_id=f1_old.id, key="mate", value="R1"))
+
+    f1_new = File(uri=uri_r1, created_on=datetime(2024, 6, 1, tzinfo=timezone.utc))
+    session.add(f1_new)
+    session.flush()
+    session.add(FileSample(file_id=f1_new.id, sample_id=sample.id))
+    session.add(FileTag(file_id=f1_new.id, key="mate", value="R1"))
+
+    # R2 file (single version)
+    f2 = File(uri=uri_r2, created_on=datetime(2024, 3, 1, tzinfo=timezone.utc))
+    session.add(f2)
+    session.flush()
+    session.add(FileSample(file_id=f2.id, sample_id=sample.id))
+    session.add(FileTag(file_id=f2.id, key="mate", value="R2"))
+
+    session.commit()
+
+    # Default (latest) — should return 2 files (one per URI)
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"include": "files"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 1
+
+    files = data[0]["files"]
+    assert files is not None
+    assert len(files) == 2
+
+    uris = {f["uri"] for f in files}
+    assert uri_r1 in uris
+    assert uri_r2 in uris
+
+
+def test_get_samples_file_versions_without_include_files_ignored(
+    client: TestClient, session: Session
+):
+    """file_versions param has no effect when include=files is not specified."""
+    project = _seed_project(session)
+    _seed_sample(session, project, "SampleNoInclude")
+    session.commit()
+
+    response = client.get(
+        f"/api/v1/projects/{project.project_id}/samples",
+        params={"file_versions": "all"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 1
+    # Should not have a 'files' key in the response
+    assert "files" not in data[0]


### PR DESCRIPTION
This PR addresses #282 with the following changes:

1. By default, GET at `api/v1/projects/{project_id}/samples?include=files` will return only the latest version of each file uri associated with the sample. To GET all versions, use `api/v1/projects/P-123/samples?include=files&file_versions=all`
2. The `created_on` key will be included in the response of `api/v1/projects/{project_id}/samples?include=files` 
3. Add tests for new functionality

