### PR TITLE
Add endpoint to return list of project attributes

### DIFF
--- a/api/project/routes.py
+++ b/api/project/routes.py
@@ -86,16 +86,15 @@ def get_projects(
     "/attributes",
     status_code=status.HTTP_200_OK,
     tags=["Project Endpoints"],
-    response_model=TypingList[Attribute],
+    response_model=TypingList[str],
 )
-def get_project_attributes(session: SessionDep) -> TypingList[Attribute]:
+def get_project_attributes(session: SessionDep) -> TypingList[str]:
     """
     Returns a list of all unique project attributes across all projects.
 
     This endpoint is useful for clients to discover what attributes are in use
     and to populate dropdowns or autocomplete fields when creating/updating
-    projects.  The response is a flat list of key-value pairs representing
-    each unique attribute.
+    projects.  The response is a flat list of unique attribute keys.
     """
     return services.get_project_attributes(session=session)
 

--- a/api/project/routes.py
+++ b/api/project/routes.py
@@ -77,6 +77,28 @@ def get_projects(
         sort_order=sort_order,
     )
 
+
+###############################################################################
+# Projects Endpoints /api/v1/projects/attributes
+###############################################################################
+
+@router.get(
+    "/attributes",
+    status_code=status.HTTP_200_OK,
+    tags=["Project Endpoints"],
+    response_model=TypingList[Attribute],
+)
+def get_project_attributes(session: SessionDep) -> TypingList[Attribute]:
+    """
+    Returns a list of all unique project attributes across all projects.
+
+    This endpoint is useful for clients to discover what attributes are in use
+    and to populate dropdowns or autocomplete fields when creating/updating
+    projects.  The response is a flat list of key-value pairs representing
+    each unique attribute.
+    """
+    return services.get_project_attributes(session=session)
+
 ###############################################################################
 # Projects Endpoints /api/v1/projects/search
 ###############################################################################

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -182,12 +182,15 @@ def get_projects(
     )
 
 
-def get_project_attributes(session: Session) -> list[ProjectAttribute]:
+def get_project_attributes(session: Session) -> list[str]:
     """
     Returns a sorted list of all unique project attributes across all projects.
     """
+    # select distinct `key` from projectattribute order by `key` asc
     return session.exec(
-        select(ProjectAttribute).distinct().order_by(ProjectAttribute.key.asc())
+        select(ProjectAttribute.key)
+        .distinct()
+        .order_by(ProjectAttribute.key.asc())
     ).all()
 
 

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -182,6 +182,15 @@ def get_projects(
     )
 
 
+def get_project_attributes(session: Session) -> list[ProjectAttribute]:
+    """
+    Returns a sorted list of all unique project attributes across all projects.
+    """
+    return session.exec(
+        select(ProjectAttribute).distinct().order_by(ProjectAttribute.key.asc())
+    ).all()
+
+
 def get_project_by_project_id(session: Session, project_id: str) -> ProjectPublic:
     """
     Returns a single project by its project_id.

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -67,6 +67,35 @@ def test_get_projects_with_data(client: TestClient, session: Session):
     assert attribute_dict["Priority"] == "High"
 
 
+def test_get_projects_attributes(client: TestClient, session: Session):
+    """Test that we get a full list of all attributes across all projects"""
+    # Add two projects with different attributes
+    project1 = Project(name="Project One")
+    project1.project_id = generate_project_id(session=session)
+    project1.attributes = [
+        ProjectAttribute(key="Department", value="R&D"),
+        ProjectAttribute(key="Priority", value="High"),
+    ]
+    session.add(project1)
+
+    project2 = Project(name="Project Two")
+    project2.project_id = generate_project_id(session=session)
+    project2.attributes = [
+        ProjectAttribute(key="Department", value="Engineering"),
+        ProjectAttribute(key="Status", value="Active"),
+    ]
+    session.add(project2)
+    session.commit()
+
+    # Get project attributes
+    response = client.get("/api/v1/projects/attributes")
+    assert response.status_code == 200
+    response_json = response.json()
+
+    expected_attributes = ["Department", "Priority", "Status"]
+    assert response_json == expected_attributes
+
+
 def test_get_project_with_sequencing_runs(client: TestClient, session: Session):
     """Test that GET /api/projects/<project_id> includes associated sequencing runs"""
     from datetime import date


### PR DESCRIPTION
This PR adds an endpoint to return a list of all attributes associated with projects.  This is used for autocomplete when creating projects.