### PR TITLE
V1 samples search clean

### DIFF
--- a/api/project/services.py
+++ b/api/project/services.py
@@ -884,20 +884,14 @@ def get_project_samples(
                     files=files if files else None,
                 )
             )
-        # Convert offset-based pagination (skip/limit) to page-based
-        per_page = limit
-        current_page = (skip // limit) + 1 if limit > 0 else 1
-        total_pages = (total_count + per_page - 1) // per_page if total_count else 0
-
         return SamplesWithFilesPublic(
             data=public_samples,
             data_cols=data_cols,
             total_items=total_count,
-            total_pages=total_pages,
-            current_page=current_page,
-            per_page=per_page,
-            has_next=current_page < total_pages,
-            has_prev=current_page > 1,
+            skip=skip,
+            limit=limit,
+            has_next=(skip + limit) < total_count,
+            has_prev=skip > 0,
         )
 
     # Default: no files
@@ -910,20 +904,14 @@ def get_project_samples(
         for sample in samples
     ]
 
-    # Convert offset-based pagination (skip/limit) to page-based
-    per_page = limit
-    current_page = (skip // limit) + 1 if limit > 0 else 1
-    total_pages = (total_count + per_page - 1) // per_page if total_count else 0
-
     return SamplesPublic(
         data=public_samples_plain,
         data_cols=data_cols,
         total_items=total_count,
-        total_pages=total_pages,
-        current_page=current_page,
-        per_page=per_page,
-        has_next=current_page < total_pages,
-        has_prev=current_page > 1,
+        skip=skip,
+        limit=limit,
+        has_next=(skip + limit) < total_count,
+        has_prev=skip > 0,
     )
 
 

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -884,14 +884,20 @@ def get_project_samples(
                     files=files if files else None,
                 )
             )
+        # Convert offset-based pagination (skip/limit) to page-based
+        per_page = limit
+        current_page = (skip // limit) + 1 if limit > 0 else 1
+        total_pages = (total_count + per_page - 1) // per_page if total_count else 0
+
         return SamplesWithFilesPublic(
             data=public_samples,
             data_cols=data_cols,
             total_items=total_count,
-            skip=skip,
-            limit=limit,
-            has_next=(skip + limit) < total_count,
-            has_prev=skip > 0,
+            total_pages=total_pages,
+            current_page=current_page,
+            per_page=per_page,
+            has_next=current_page < total_pages,
+            has_prev=current_page > 1,
         )
 
     # Default: no files
@@ -904,14 +910,20 @@ def get_project_samples(
         for sample in samples
     ]
 
+    # Convert offset-based pagination (skip/limit) to page-based
+    per_page = limit
+    current_page = (skip // limit) + 1 if limit > 0 else 1
+    total_pages = (total_count + per_page - 1) // per_page if total_count else 0
+
     return SamplesPublic(
         data=public_samples_plain,
         data_cols=data_cols,
         total_items=total_count,
-        skip=skip,
-        limit=limit,
-        has_next=(skip + limit) < total_count,
-        has_prev=skip > 0,
+        total_pages=total_pages,
+        current_page=current_page,
+        per_page=per_page,
+        has_next=current_page < total_pages,
+        has_prev=current_page > 1,
     )
 
 

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -10,6 +10,7 @@ from api.utils import check_duplicate_attribute_keys
 from pydantic import PositiveInt
 from pytz import timezone
 from sqlmodel import Session, func, select
+from sqlalchemy.orm import selectinload
 from opensearchpy import OpenSearch
 import yaml
 
@@ -417,19 +418,53 @@ def search_projects(
     search_body = define_search_body(query, page, per_page, sort_by, sort_order)
 
     try:
-
         response = client.search(index="projects", body=search_body)
         total_items = response["hits"]["total"]["value"]
         total_pages = (total_items + per_page - 1) // per_page  # Ceiling division
 
-        # Unpack search results into ProjectPublic model
-        results = []
-        for hit in response["hits"]["hits"]:
-            source = hit["_source"]
-            project = get_project_by_project_id(
-                session=session, project_id=source.get("project_id")
+        # Batch database lookup: collect all project_ids first
+        project_ids = [hit["_source"].get("project_id") for hit in response["hits"]["hits"]]
+        
+        if not project_ids:
+            return ProjectsPublic(
+                data=[],
+                total_items=total_items,
+                total_pages=total_pages,
+                current_page=page,
+                per_page=per_page,
+                has_next=page < total_pages,
+                has_prev=page > 1,
             )
-            results.append(ProjectPublic.model_validate(project))
+        
+        # Single query to fetch all projects with their attributes
+        projects = session.exec(
+            select(Project)
+            .options(selectinload(Project.attributes))
+            .where(Project.project_id.in_(project_ids))
+        ).all()
+        
+        # Fetch settings once (not per-project)
+        data_bucket = get_setting_value(session, "DATA_BUCKET_URI")
+        results_bucket = get_setting_value(session, "RESULTS_BUCKET_URI")
+        
+        # Create lookup map for O(1) access
+        project_map = {project.project_id: project for project in projects}
+        
+        # Preserve OpenSearch ranking order
+        results = []
+        for project_id in project_ids:
+            project = project_map.get(project_id)
+            if project:
+                results.append(
+                    ProjectPublic(
+                        project_id=project.project_id,
+                        name=project.name,
+                        data_folder_uri=f"{data_bucket}/{project.project_id}/",
+                        results_folder_uri=f"{results_bucket}/{project.project_id}/",
+                        attributes=project.attributes,
+                        sequencing_runs=None,  # Not included for performance (matches get_projects)
+                    )
+                )
 
         return ProjectsPublic(
             data=results,

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -436,7 +436,7 @@ def search_projects(
 
         # Batch database lookup: collect all project_ids first
         project_ids = [hit["_source"].get("project_id") for hit in response["hits"]["hits"]]
-        
+
         if not project_ids:
             return ProjectsPublic(
                 data=[],
@@ -447,21 +447,21 @@ def search_projects(
                 has_next=page < total_pages,
                 has_prev=page > 1,
             )
-        
+
         # Single query to fetch all projects with their attributes
         projects = session.exec(
             select(Project)
             .options(selectinload(Project.attributes))
             .where(Project.project_id.in_(project_ids))
         ).all()
-        
+
         # Fetch settings once (not per-project)
         data_bucket = get_setting_value(session, "DATA_BUCKET_URI")
         results_bucket = get_setting_value(session, "RESULTS_BUCKET_URI")
-        
+
         # Create lookup map for O(1) access
         project_map = {project.project_id: project for project in projects}
-        
+
         # Preserve OpenSearch ranking order
         results = []
         for project_id in project_ids:

--- a/api/runs/services.py
+++ b/api/runs/services.py
@@ -198,7 +198,6 @@ def search_runs(
         ]
 
     try:
-
         response = client.search(index="illumina_runs", body=search_body)
 
         # Total Items and Pages needs to be calculated from OpenSearch response
@@ -206,11 +205,33 @@ def search_runs(
         total_items = response["hits"]["total"]["value"]
         total_pages = (total_items + per_page - 1) // per_page  # Ceiling division
 
-        # Unpack search results into ProjectPublic model
+        # Batch database lookup: collect all run_ids first
+        run_ids = [hit["_source"].get("run_id") for hit in response["hits"]["hits"]]
+        
+        if not run_ids:
+            return SequencingRunsPublic(
+                data=[],
+                total_items=total_items,
+                total_pages=total_pages,
+                current_page=page,
+                per_page=per_page,
+                has_next=page < total_pages,
+                has_prev=page > 1,
+            )
+        
+        # Single query to fetch all runs
+        runs = session.exec(
+            select(SequencingRun)
+            .where(SequencingRun.run_id.in_(run_ids))
+        ).all()
+        
+        # Create lookup map for O(1) access
+        run_map = {run.run_id: run for run in runs}
+        
+        # Preserve OpenSearch ranking order
         results = []
-        for hit in response["hits"]["hits"]:
-            source = hit["_source"]
-            run = get_run(session=session, run_id=source.get("run_id"))
+        for run_id in run_ids:
+            run = run_map.get(run_id)
             if run:
                 results.append(SequencingRunPublic.model_validate(run))
 

--- a/api/runs/services.py
+++ b/api/runs/services.py
@@ -207,7 +207,7 @@ def search_runs(
 
         # Batch database lookup: collect all run_ids first
         run_ids = [hit["_source"].get("run_id") for hit in response["hits"]["hits"]]
-        
+
         if not run_ids:
             return SequencingRunsPublic(
                 data=[],
@@ -218,16 +218,16 @@ def search_runs(
                 has_next=page < total_pages,
                 has_prev=page > 1,
             )
-        
+
         # Single query to fetch all runs
         runs = session.exec(
             select(SequencingRun)
             .where(SequencingRun.run_id.in_(run_ids))
         ).all()
-        
+
         # Create lookup map for O(1) access
         run_map = {run.run_id: run for run in runs}
-        
+
         # Preserve OpenSearch ranking order
         results = []
         for run_id in run_ids:

--- a/api/samples/models.py
+++ b/api/samples/models.py
@@ -73,11 +73,24 @@ class SamplePublic(SQLModel):
 
 
 class SamplesPublic(SQLModel):
+    """Paginated list of samples using offset-based pagination (skip/limit)."""
     data: List[SamplePublic]
     data_cols: list[str] | None = None
     total_items: int
     skip: int
     limit: int
+    has_next: bool
+    has_prev: bool
+
+
+class SamplesPublicSearchResponse(SQLModel):
+    """Paginated list of samples using page-based pagination for search endpoints."""
+    data: List[SamplePublic]
+    data_cols: list[str] | None = None
+    total_items: int
+    total_pages: int
+    current_page: int
+    per_page: int
     has_next: bool
     has_prev: bool
 

--- a/api/samples/models.py
+++ b/api/samples/models.py
@@ -76,9 +76,8 @@ class SamplesPublic(SQLModel):
     data: List[SamplePublic]
     data_cols: list[str] | None = None
     total_items: int
-    total_pages: int
-    current_page: int
-    per_page: int
+    skip: int
+    limit: int
     has_next: bool
     has_prev: bool
 
@@ -105,9 +104,8 @@ class SamplesWithFilesPublic(SQLModel):
     data: List[SampleWithFilesPublic]
     data_cols: list[str] | None = None
     total_items: int
-    total_pages: int
-    current_page: int
-    per_page: int
+    skip: int
+    limit: int
     has_next: bool
     has_prev: bool
 

--- a/api/samples/models.py
+++ b/api/samples/models.py
@@ -29,7 +29,7 @@ class SampleAttribute(SQLModel, table=True):
 
 
 class Sample(SQLModel, table=True):
-    __searchable__ = ["sample_id"]
+    __searchable__ = ["sample_id", "project_id"]
 
     id: uuid.UUID | None = Field(default_factory=uuid.uuid4, primary_key=True)
     sample_id: str
@@ -150,3 +150,15 @@ class BulkSampleCreateResponse(SQLModel):
     files_created: int = 0
     files_skipped: int = 0
     items: List[BulkSampleItemResponse]
+
+
+# ---------------------------------------------------------------------------
+# Sample search request model
+# ---------------------------------------------------------------------------
+
+
+class SampleSearchRequest(SQLModel):
+    """POST /api/v1/samples/search request body."""
+    filter_on: dict = {}
+    page: int = 1
+    per_page: int = 20

--- a/api/samples/models.py
+++ b/api/samples/models.py
@@ -76,8 +76,9 @@ class SamplesPublic(SQLModel):
     data: List[SamplePublic]
     data_cols: list[str] | None = None
     total_items: int
-    skip: int
-    limit: int
+    total_pages: int
+    current_page: int
+    per_page: int
     has_next: bool
     has_prev: bool
 
@@ -104,8 +105,9 @@ class SamplesWithFilesPublic(SQLModel):
     data: List[SampleWithFilesPublic]
     data_cols: list[str] | None = None
     total_items: int
-    skip: int
-    limit: int
+    total_pages: int
+    current_page: int
+    per_page: int
     has_next: bool
     has_prev: bool
 

--- a/api/samples/routes.py
+++ b/api/samples/routes.py
@@ -4,7 +4,7 @@ Routes/endpoints for the Samples API
 
 from fastapi import APIRouter, Request, Query, status
 from core.deps import SessionDep, OpenSearchDep
-from api.samples.models import SamplesPublic, SampleSearchRequest
+from api.samples.models import SamplesPublicSearchResponse, SampleSearchRequest
 import api.samples.services as services
 
 router = APIRouter(prefix="/samples", tags=["Sample Endpoints"])
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/samples", tags=["Sample Endpoints"])
 
 @router.get(
     "/search",
-    response_model=SamplesPublic,
+    response_model=SamplesPublicSearchResponse,
     status_code=status.HTTP_200_OK,
     tags=["Sample Endpoints"],
 )
@@ -26,7 +26,7 @@ def search_samples_get(
     session: SessionDep,
     page: int = Query(1, description="Page number (1-indexed)"),
     per_page: int = Query(20, description="Number of items per page"),
-) -> SamplesPublic:
+) -> SamplesPublicSearchResponse:
     """
     Search samples using query string parameters.
 
@@ -57,14 +57,14 @@ def search_samples_get(
 
 @router.post(
     "/search",
-    response_model=SamplesPublic,
+    response_model=SamplesPublicSearchResponse,
     status_code=status.HTTP_200_OK,
     tags=["Sample Endpoints"],
 )
 def search_samples_post(
     session: SessionDep,
     body: SampleSearchRequest,
-) -> SamplesPublic:
+) -> SamplesPublicSearchResponse:
     """
     Search samples using JSON body with filter_on, page, per_page.
 

--- a/api/samples/routes.py
+++ b/api/samples/routes.py
@@ -47,7 +47,7 @@ def search_samples_get(
         k: v for k, v in request.query_params.items()
         if k not in excluded
     }
-    return services.search_samples_v1(
+    return services.search_samples(
         session=session,
         filters=query_params,
         page=page,
@@ -95,7 +95,7 @@ def search_samples_post(
     filters = {k: v for k, v in body.filter_on.items() if k != "tags"}
     tags = body.filter_on.get("tags")
 
-    return services.search_samples_v1(
+    return services.search_samples(
         session=session,
         filters=filters,
         tags=tags,

--- a/api/samples/routes.py
+++ b/api/samples/routes.py
@@ -2,32 +2,115 @@
 Routes/endpoints for the Samples API
 """
 
-# from typing import Literal
-from fastapi import APIRouter, status  # Query
+from fastapi import APIRouter, Request, Query, status
 from core.deps import SessionDep, OpenSearchDep
-# from api.samples.models import Sample, SampleCreate, SamplePublic, SamplesPublic
+from api.samples.models import SamplesPublic, SampleSearchRequest
 import api.samples.services as services
 
 router = APIRouter(prefix="/samples", tags=["Sample Endpoints"])
 
-# @router.get(
-#  "/{sample_id}",
-#  response_model=SamplePublic,
-#  tags=["Sample Endpoints"]
-# )
-# def get_sample_by_sample_id(session: SessionDep, sample_id: str) -> Sample:
-#  """
-#  Returns a single sample by its sample_id.
-#  Note: This is different from its internal "id".
-#  """
-#  return services.get_sample_by_sample_id(
-#    session=session,
-#    sample_id=sample_id
-#  )
+
+# ---------------------------------------------------------------------------
+# Search endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/search",
+    response_model=SamplesPublic,
+    status_code=status.HTTP_200_OK,
+    tags=["Sample Endpoints"],
+)
+def search_samples_get(
+    request: Request,
+    session: SessionDep,
+    page: int = Query(1, description="Page number (1-indexed)"),
+    per_page: int = Query(20, description="Number of items per page"),
+) -> SamplesPublic:
+    """
+    Search samples using query string parameters.
+
+    Accepts key/value pairs as query params, e.g.:
+    ``?projectid=P-1234&samplename=Sample_1&page=1&per_page=20``
+
+    Supported filter keys:
+    - ``projectid``: exact match on project ID
+    - ``samplename``: exact match on sample name
+    - ``created_on``: date prefix match (YYYY-MM-DD) on created_at
+    - Any other key: matched against sample attributes (case-insensitive key)
+
+    Multiple filters are AND'd together.
+    """
+    # Convert query params to dict, excluding pagination and cache-busting
+    excluded = {"page", "per_page", "_"}
+    query_params = {
+        k: v for k, v in request.query_params.items()
+        if k not in excluded
+    }
+    return services.search_samples_v1(
+        session=session,
+        filters=query_params,
+        page=page,
+        per_page=per_page,
+    )
 
 
 @router.post(
     "/search",
+    response_model=SamplesPublic,
+    status_code=status.HTTP_200_OK,
+    tags=["Sample Endpoints"],
+)
+def search_samples_post(
+    session: SessionDep,
+    body: SampleSearchRequest,
+) -> SamplesPublic:
+    """
+    Search samples using JSON body with filter_on, page, per_page.
+
+    Example body::
+
+        {
+            "filter_on": {
+                "projectid": "P-1234",
+                "tags": {
+                    "USUBJID": "CA123012-01-234"
+                }
+            },
+            "page": 1,
+            "per_page": 20
+        }
+
+    ``filter_on`` supports:
+    - ``projectid`` (str or list)
+    - ``samplename`` (str or list)
+    - ``created_on`` (str, date prefix match)
+    - ``tags`` (dict of key/value pairs, matched case-insensitively)
+    - Any other key is matched against sample attributes
+
+    List values are OR'd; multiple keys are AND'd.
+    """
+    # Separate tags before passing to service (since _build_sample_query
+    # mutates filters dict)
+    filters = {k: v for k, v in body.filter_on.items() if k != "tags"}
+    tags = body.filter_on.get("tags")
+
+    return services.search_samples_v1(
+        session=session,
+        filters=filters,
+        tags=tags,
+        page=body.page,
+        per_page=body.per_page,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reindex endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/reindex",
     status_code=status.HTTP_201_CREATED,
     tags=["Sample Endpoints"],
 )

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -542,15 +542,35 @@ def search_samples_opensearch(
             (total_items + per_page - 1) // per_page if total_items else 0
         )
 
+        # Batch database lookup: collect all sample UUIDs first
+        sample_uuids = [hit["_id"] for hit in response["hits"]["hits"]]
+        
+        if not sample_uuids:
+            return SamplesPublicSearchResponse(
+                data=[],
+                data_cols=None,
+                total_items=total_items,
+                total_pages=total_pages,
+                current_page=page,
+                per_page=per_page,
+                has_next=page < total_pages,
+                has_prev=page > 1,
+            )
+        
+        # Single query to fetch all samples
+        samples = session.exec(
+            select(Sample)
+            .options(selectinload(Sample.attributes))
+            .where(Sample.id.in_(sample_uuids))
+        ).all()
+        
+        # Create lookup map for O(1) access
+        sample_map = {str(sample.id): sample for sample in samples}
+        
+        # Preserve OpenSearch ranking order
         results = []
-        for hit in response["hits"]["hits"]:
-            # The _id is the sample UUID; look up full record from DB
-            sample_uuid = hit["_id"]
-            sample = session.exec(
-                select(Sample)
-                .options(selectinload(Sample.attributes))
-                .where(Sample.id == sample_uuid)
-            ).first()
+        for sample_uuid in sample_uuids:
+            sample = sample_map.get(sample_uuid)
             if sample:
                 results.append(
                     SamplePublic(

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -219,14 +219,6 @@ def get_samples(
     )
 
 
-def get_sample_by_sample_id(session: Session, sample_id: str) -> Sample:
-    """
-    Returns a single sample by its sample_id.
-    Note: This is different from its internal "id".
-    """
-    return None
-
-
 def reindex_samples(
     session: Session, client: OpenSearch, batch_size: int = 5000
 ):

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 from datetime import datetime, timezone
 from typing import List, Literal
@@ -6,7 +5,11 @@ from typing import List, Literal
 from fastapi import HTTPException, status
 from api.utils import check_duplicate_attribute_keys
 from sqlmodel import Session, select, func
+from sqlalchemy.orm import selectinload
 from opensearchpy import OpenSearch
+
+from core.utils import define_search_body
+from core.logger import logger
 
 from api.samples.models import (
     Sample,
@@ -27,8 +30,6 @@ from api.search.services import (
     add_objects_to_index,
     reset_index,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def resolve_or_create_sample(
@@ -229,6 +230,7 @@ def reindex_samples(
     session: Session, client: OpenSearch, batch_size: int = 5000
 ):
     """
+<<<<<<< HEAD
     Index all samples in database with OpenSearch.
 
     Processes samples in batches to bound memory usage for large datasets.
@@ -343,6 +345,237 @@ def delete_sample(
         sample_id, sample.id, project_id,
     )
 
+
+# ---------------------------------------------------------------------------
+# Shared sample query builder (used by v1 endpoints)
+# ---------------------------------------------------------------------------
+
+
+# Top-level fields that map to Sample columns
+FIELD_MAP = {
+    "projectid": "project_id",
+    "samplename": "sample_id",
+}
+
+
+def _build_sample_query(
+    filters: dict,
+    tags: dict | None = None,
+):
+    """
+    Build a SQLAlchemy select statement from sample filter parameters.
+
+    Args:
+        filters: dict of top-level or attribute filters.
+            - Keys in FIELD_MAP are mapped to Sample columns.
+            - 'created_on' is handled as date prefix match.
+            - 'tags' key (if present) is extracted and handled separately.
+            - Other keys are treated as SampleAttribute key searches.
+        tags: Explicit tags dict (from POST body's filter_on.tags).
+
+    Returns:
+        A select statement for Sample objects with attributes eager-loaded.
+    """
+    statement = select(Sample).options(selectinload(Sample.attributes))
+
+    # Extract tags from filters if present
+    if tags is None:
+        tags = filters.pop("tags", None)
+    else:
+        filters.pop("tags", None)  # Remove if also present in filters
+
+    # Handle top-level and attribute filters
+    attr_filters = {}
+    for key, value in filters.items():
+        column_name = FIELD_MAP.get(key)
+        if column_name:
+            # Map to Sample column
+            column = getattr(Sample, column_name)
+            if isinstance(value, list):
+                statement = statement.where(column.in_(value))
+            else:
+                statement = statement.where(column == value)
+        elif key == "created_on":
+            # Date prefix match on Sample.created_at
+            # e.g., "2026-01-21" matches any timestamp on that date
+            if isinstance(value, str) and Sample.created_at is not None:
+                try:
+                    date = datetime.strptime(value, "%Y-%m-%d").date()
+                    statement = statement.where(
+                        func.date(Sample.created_at) == date
+                    )
+                except ValueError:
+                    pass  # Invalid date format, skip filter
+        else:
+            # Unknown key — treat as attribute filter
+            attr_filters[key] = value
+
+    # Handle attribute filters (from unknown keys)
+    for attr_key, attr_value in attr_filters.items():
+        # Case-insensitive key matching
+        attr_subquery = (
+            select(SampleAttribute.sample_id)
+            .where(
+                func.upper(SampleAttribute.key) == attr_key.upper(),
+                SampleAttribute.value == attr_value,
+            )
+        )
+        statement = statement.where(Sample.id.in_(attr_subquery))
+
+    # Handle tags dict (from POST body)
+    if tags and isinstance(tags, dict):
+        for tag_key, tag_value in tags.items():
+            attr_subquery = (
+                select(SampleAttribute.sample_id)
+                .where(
+                    func.upper(SampleAttribute.key) == tag_key.upper(),
+                    SampleAttribute.value == tag_value,
+                )
+            )
+            statement = statement.where(Sample.id.in_(attr_subquery))
+
+    return statement
+
+
+# ---------------------------------------------------------------------------
+# V1 structured sample search (SQL-backed)
+# ---------------------------------------------------------------------------
+
+
+def search_samples_v1(
+    session: Session,
+    filters: dict,
+    tags: dict | None = None,
+    page: int = 1,
+    per_page: int = 20,
+) -> SamplesPublic:
+    """
+    Search samples using structured filters, returning v1 response format.
+
+    Args:
+        session: Database session
+        filters: dict of filter parameters (projectid, samplename,
+                 created_on, attribute keys, tags)
+        tags: Optional explicit tags dict
+        page: Page number (1-indexed)
+        per_page: Number of items per page
+
+    Returns:
+        SamplesPublic with paginated results and data_cols
+    """
+    # Build query for total count (without pagination)
+    # We need separate copies because _build_sample_query mutates filters
+    count_filters = dict(filters)
+    count_tags = dict(tags) if tags else None
+    count_stmt = _build_sample_query(count_filters, count_tags)
+    all_results = session.exec(count_stmt).all()
+    total_count = len(all_results)
+
+    total_pages = (total_count + per_page - 1) // per_page if total_count else 0
+
+    # Build query with pagination
+    page_filters = dict(filters)
+    page_tags = dict(tags) if tags else None
+    statement = _build_sample_query(page_filters, page_tags)
+    offset = (page - 1) * per_page
+    statement = statement.offset(offset).limit(per_page)
+    samples = session.exec(statement).all()
+
+    # Map to SamplePublic
+    public_samples = [
+        SamplePublic(
+            sample_id=sample.sample_id,
+            project_id=sample.project_id,
+            attributes=sample.attributes,
+        )
+        for sample in samples
+    ]
+
+    # Collect all unique attribute keys across matched samples for data_cols
+    data_cols = None
+    if samples:
+        all_keys = set()
+        for sample in samples:
+            if sample.attributes:
+                for attr in sample.attributes:
+                    all_keys.add(attr.key)
+        data_cols = sorted(list(all_keys)) if all_keys else None
+
+    return SamplesPublic(
+        data=public_samples,
+        data_cols=data_cols,
+        total_items=total_count,
+        total_pages=total_pages,
+        current_page=page,
+        per_page=per_page,
+        has_next=page < total_pages,
+        has_prev=page > 1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpenSearch free-text sample search (for unified /api/v1/search)
+# ---------------------------------------------------------------------------
+
+
+def search_samples_opensearch(
+    session: Session,
+    client: OpenSearch,
+    query: str,
+    page: int = 1,
+    per_page: int = 5,
+    sort_by: str | None = "sample_id",
+    sort_order: Literal["asc", "desc"] | None = "asc",
+) -> SamplesPublic:
+    """
+    Search samples using OpenSearch free-text query.
+    Used by the unified /api/v1/search endpoint.
+    """
+    search_body = define_search_body(
+        query, page, per_page, sort_by, sort_order
+    )
+
+    try:
+        response = client.search(index="samples", body=search_body)
+        total_items = response["hits"]["total"]["value"]
+        total_pages = (
+            (total_items + per_page - 1) // per_page if total_items else 0
+        )
+
+        results = []
+        for hit in response["hits"]["hits"]:
+            # The _id is the sample UUID; look up full record from DB
+            sample_uuid = hit["_id"]
+            sample = session.exec(
+                select(Sample)
+                .options(selectinload(Sample.attributes))
+                .where(Sample.id == sample_uuid)
+            ).first()
+            if sample:
+                results.append(
+                    SamplePublic(
+                        sample_id=sample.sample_id,
+                        project_id=sample.project_id,
+                        attributes=sample.attributes,
+                    )
+                )
+
+        return SamplesPublic(
+            data=results,
+            data_cols=None,
+            total_items=total_items,
+            total_pages=total_pages,
+            current_page=page,
+            per_page=per_page,
+            has_next=page < total_pages,
+            has_prev=page > 1,
+        )
+    except Exception as e:
+        logger.error("OpenSearch sample search failed: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
 
 # ---------------------------------------------------------------------------
 # Sample file creation helper (hash-aware dedup)

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -17,6 +17,7 @@ from api.samples.models import (
     SampleFileInput,
     SamplePublic,
     SamplesPublic,
+    SamplesPublicSearchResponse,
     SampleAttribute,
     BulkSampleCreateResponse,
     BulkSampleItemResponse,
@@ -447,7 +448,7 @@ def search_samples(
     tags: dict | None = None,
     page: int = 1,
     per_page: int = 20,
-) -> SamplesPublic:
+) -> SamplesPublicSearchResponse:
     """
     Search samples using structured filters.
 
@@ -460,7 +461,7 @@ def search_samples(
         per_page: Number of items per page
 
     Returns:
-        SamplesPublic with paginated results and data_cols
+        SamplesPublicSearchResponse with paginated results and data_cols
     """
     # Build query for total count (without pagination)
     # We need separate copies because _build_sample_query mutates filters
@@ -500,7 +501,7 @@ def search_samples(
                     all_keys.add(attr.key)
         data_cols = sorted(list(all_keys)) if all_keys else None
 
-    return SamplesPublic(
+    return SamplesPublicSearchResponse(
         data=public_samples,
         data_cols=data_cols,
         total_items=total_count,
@@ -525,7 +526,7 @@ def search_samples_opensearch(
     per_page: int = 5,
     sort_by: str | None = "sample_id",
     sort_order: Literal["asc", "desc"] | None = "asc",
-) -> SamplesPublic:
+) -> SamplesPublicSearchResponse:
     """
     Search samples using OpenSearch free-text query.
     Used by the unified /api/v1/search endpoint.
@@ -559,7 +560,7 @@ def search_samples_opensearch(
                     )
                 )
 
-        return SamplesPublic(
+        return SamplesPublicSearchResponse(
             data=results,
             data_cols=None,
             total_items=total_items,

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -230,7 +230,6 @@ def reindex_samples(
     session: Session, client: OpenSearch, batch_size: int = 5000
 ):
     """
-<<<<<<< HEAD
     Index all samples in database with OpenSearch.
 
     Processes samples in batches to bound memory usage for large datasets.
@@ -442,7 +441,7 @@ def _build_sample_query(
 # ---------------------------------------------------------------------------
 
 
-def search_samples_v1(
+def search_samples(
     session: Session,
     filters: dict,
     tags: dict | None = None,
@@ -450,7 +449,7 @@ def search_samples_v1(
     per_page: int = 20,
 ) -> SamplesPublic:
     """
-    Search samples using structured filters, returning v1 response format.
+    Search samples using structured filters.
 
     Args:
         session: Database session

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -207,14 +207,20 @@ def get_samples(
                     all_keys.add(attr.key)
         data_cols = sorted(list(all_keys)) if all_keys else None
 
+    # Convert offset-based pagination (skip/limit) to page-based
+    per_page = limit
+    current_page = (skip // limit) + 1 if limit > 0 else 1
+    total_pages = (total_count + per_page - 1) // per_page if total_count else 0
+
     return SamplesPublic(
         data=public_samples,
         data_cols=data_cols,
         total_items=total_count,
-        skip=skip,
-        limit=limit,
-        has_next=(skip + limit) < total_count,
-        has_prev=skip > 0,
+        total_pages=total_pages,
+        current_page=current_page,
+        per_page=per_page,
+        has_next=current_page < total_pages,
+        has_prev=current_page > 1,
     )
 
 

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -485,7 +485,7 @@ def search_samples(
             if sample.attributes:
                 for attr in sample.attributes:
                     all_keys.add(attr.key)
-        data_cols = sorted(list(all_keys)) if all_keys else None
+        data_cols = sorted(all_keys) if all_keys else None
 
     return SamplesPublicSearchResponse(
         data=public_samples,

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -207,20 +207,14 @@ def get_samples(
                     all_keys.add(attr.key)
         data_cols = sorted(list(all_keys)) if all_keys else None
 
-    # Convert offset-based pagination (skip/limit) to page-based
-    per_page = limit
-    current_page = (skip // limit) + 1 if limit > 0 else 1
-    total_pages = (total_count + per_page - 1) // per_page if total_count else 0
-
     return SamplesPublic(
         data=public_samples,
         data_cols=data_cols,
         total_items=total_count,
-        total_pages=total_pages,
-        current_page=current_page,
-        per_page=per_page,
-        has_next=current_page < total_pages,
-        has_prev=current_page > 1,
+        skip=skip,
+        limit=limit,
+        has_next=(skip + limit) < total_count,
+        has_prev=skip > 0,
     )
 
 

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -206,7 +206,7 @@ def get_samples(
             if sample.attributes:
                 for attr in sample.attributes:
                     all_keys.add(attr.key)
-        data_cols = sorted(list(all_keys)) if all_keys else None
+        data_cols = sorted(all_keys) if all_keys else None
 
     return SamplesPublic(
         data=public_samples,
@@ -530,7 +530,7 @@ def search_samples_opensearch(
 
         # Batch database lookup: collect all sample UUIDs first
         sample_uuids = [hit["_id"] for hit in response["hits"]["hits"]]
-        
+
         if not sample_uuids:
             return SamplesPublicSearchResponse(
                 data=[],
@@ -542,17 +542,17 @@ def search_samples_opensearch(
                 has_next=page < total_pages,
                 has_prev=page > 1,
             )
-        
+
         # Single query to fetch all samples
         samples = session.exec(
             select(Sample)
             .options(selectinload(Sample.attributes))
             .where(Sample.id.in_(sample_uuids))
         ).all()
-        
+
         # Create lookup map for O(1) access
         sample_map = {str(sample.id): sample for sample in samples}
-        
+
         # Preserve OpenSearch ranking order
         results = []
         for sample_uuid in sample_uuids:

--- a/api/samples/services.py
+++ b/api/samples/services.py
@@ -358,6 +358,33 @@ FIELD_MAP = {
 }
 
 
+def _apply_attribute_filter(statement, attr_key: str, attr_value: str):
+    """Apply a single attribute filter as an EXISTS subquery (case-insensitive key)."""
+    attr_subquery = select(SampleAttribute.sample_id).where(
+        func.upper(SampleAttribute.key) == attr_key.upper(),
+        SampleAttribute.value == attr_value,
+    )
+    return statement.where(Sample.id.in_(attr_subquery))
+
+
+def _apply_column_filter(statement, column, value):
+    """Apply a filter on a Sample column, supporting list (IN) or scalar (==)."""
+    if isinstance(value, list):
+        return statement.where(column.in_(value))
+    return statement.where(column == value)
+
+
+def _apply_date_filter(statement, value: str):
+    """Apply a date prefix filter on Sample.created_at (e.g. '2026-01-21')."""
+    if not isinstance(value, str) or Sample.created_at is None:
+        return statement
+    try:
+        date = datetime.strptime(value, "%Y-%m-%d").date()
+        return statement.where(func.date(Sample.created_at) == date)
+    except ValueError:
+        return statement  # Invalid date format — skip
+
+
 def _build_sample_query(
     filters: dict,
     tags: dict | None = None,
@@ -382,57 +409,24 @@ def _build_sample_query(
     if tags is None:
         tags = filters.pop("tags", None)
     else:
-        filters.pop("tags", None)  # Remove if also present in filters
+        filters.pop("tags", None)
 
-    # Handle top-level and attribute filters
-    attr_filters = {}
+    # Apply top-level column filters, date filter, or attribute filters
     for key, value in filters.items():
         column_name = FIELD_MAP.get(key)
         if column_name:
-            # Map to Sample column
-            column = getattr(Sample, column_name)
-            if isinstance(value, list):
-                statement = statement.where(column.in_(value))
-            else:
-                statement = statement.where(column == value)
-        elif key == "created_on":
-            # Date prefix match on Sample.created_at
-            # e.g., "2026-01-21" matches any timestamp on that date
-            if isinstance(value, str) and Sample.created_at is not None:
-                try:
-                    date = datetime.strptime(value, "%Y-%m-%d").date()
-                    statement = statement.where(
-                        func.date(Sample.created_at) == date
-                    )
-                except ValueError:
-                    pass  # Invalid date format, skip filter
-        else:
-            # Unknown key — treat as attribute filter
-            attr_filters[key] = value
-
-    # Handle attribute filters (from unknown keys)
-    for attr_key, attr_value in attr_filters.items():
-        # Case-insensitive key matching
-        attr_subquery = (
-            select(SampleAttribute.sample_id)
-            .where(
-                func.upper(SampleAttribute.key) == attr_key.upper(),
-                SampleAttribute.value == attr_value,
+            statement = _apply_column_filter(
+                statement, getattr(Sample, column_name), value
             )
-        )
-        statement = statement.where(Sample.id.in_(attr_subquery))
+        elif key == "created_on":
+            statement = _apply_date_filter(statement, value)
+        else:
+            statement = _apply_attribute_filter(statement, key, value)
 
-    # Handle tags dict (from POST body)
+    # Apply tag filters (same semantics as attribute filters)
     if tags and isinstance(tags, dict):
         for tag_key, tag_value in tags.items():
-            attr_subquery = (
-                select(SampleAttribute.sample_id)
-                .where(
-                    func.upper(SampleAttribute.key) == tag_key.upper(),
-                    SampleAttribute.value == tag_value,
-                )
-            )
-            statement = statement.where(Sample.id.in_(attr_subquery))
+            statement = _apply_attribute_filter(statement, tag_key, tag_value)
 
     return statement
 

--- a/api/search/models.py
+++ b/api/search/models.py
@@ -5,7 +5,7 @@ from typing import List, Any, Union
 from pydantic import BaseModel
 from api.project.models import ProjectPublic, ProjectsPublic
 from api.runs.models import SequencingRunPublic, SequencingRunsPublic
-from api.samples.models import SamplesPublic
+from api.samples.models import SamplesPublicSearchResponse
 
 
 class SearchDocument(BaseModel):
@@ -51,4 +51,4 @@ SearchResponseOriginal = Union[
 class SearchResponse(BaseModel):
     projects: ProjectsPublic
     runs: SequencingRunsPublic
-    samples: SamplesPublic
+    samples: SamplesPublicSearchResponse

--- a/api/search/models.py
+++ b/api/search/models.py
@@ -5,6 +5,7 @@ from typing import List, Any, Union
 from pydantic import BaseModel
 from api.project.models import ProjectPublic, ProjectsPublic
 from api.runs.models import SequencingRunPublic, SequencingRunsPublic
+from api.samples.models import SamplesPublic
 
 
 class SearchDocument(BaseModel):
@@ -50,3 +51,4 @@ SearchResponseOriginal = Union[
 class SearchResponse(BaseModel):
     projects: ProjectsPublic
     runs: SequencingRunsPublic
+    samples: SamplesPublic

--- a/api/search/services.py
+++ b/api/search/services.py
@@ -134,6 +134,7 @@ def search(
     """
     from api.project.services import search_projects
     from api.runs.services import search_runs
+    from api.samples.services import search_samples_opensearch
 
     args = {
         "session": session,
@@ -143,4 +144,8 @@ def search(
         "per_page": n_results,
     }
 
-    return SearchResponse(projects=search_projects(**args), runs=search_runs(**args))
+    return SearchResponse(
+        projects=search_projects(**args),
+        runs=search_runs(**args),
+        samples=search_samples_opensearch(**args),
+    )

--- a/docs/SAMPLES_SEARCH.md
+++ b/docs/SAMPLES_SEARCH.md
@@ -1,0 +1,397 @@
+# Sample Search API
+
+The Sample Search API provides two complementary search capabilities:
+
+1. **Structured Search** (`/api/v1/samples/search`) - Filter samples by exact criteria (project, name, dates, attributes)
+2. **Unified Free-Text Search** (`/api/v1/search`) - Search across projects, runs, and samples with a single query
+
+---
+
+## Structured Sample Search
+
+Search samples using exact filters on project ID, sample name, creation date, and custom attributes.
+
+### Endpoints
+
+- `GET /api/v1/samples/search` - Search using query parameters
+- `POST /api/v1/samples/search` - Search using JSON request body
+
+Both endpoints return paginated results in the same format.
+
+### Response Format
+
+```json
+{
+  "data": [
+    {
+      "sample_id": "Sample_001",
+      "project_id": "P-1234",
+      "attributes": [
+        {"key": "Tissue", "value": "Liver"},
+        {"key": "USUBJID", "value": "CA123012-01-234"}
+      ]
+    }
+  ],
+  "data_cols": ["Tissue", "USUBJID"],
+  "total_items": 42,
+  "total_pages": 3,
+  "current_page": 1,
+  "per_page": 20,
+  "has_next": true,
+  "has_prev": false
+}
+```
+
+**Response Fields:**
+- `data` - Array of matching samples
+- `data_cols` - List of all attribute keys found across matched samples (useful for building dynamic tables)
+- Pagination metadata: `total_items`, `total_pages`, `current_page`, `per_page`, `has_next`, `has_prev`
+
+---
+
+## GET: Search with Query Parameters
+
+Use query parameters for simple filtering.
+
+### Examples
+
+**Filter by project:**
+```bash
+GET /api/v1/samples/search?projectid=P-1234
+```
+
+**Filter by sample name:**
+```bash
+GET /api/v1/samples/search?samplename=Sample_001
+```
+
+**Filter by creation date:**
+```bash
+GET /api/v1/samples/search?created_on=2026-01-21
+```
+
+**Filter by custom attribute:**
+```bash
+GET /api/v1/samples/search?Tissue=Liver
+```
+
+**Multiple filters (AND logic):**
+```bash
+GET /api/v1/samples/search?projectid=P-1234&Tissue=Liver&created_on=2026-01-21
+```
+
+**With pagination:**
+```bash
+GET /api/v1/samples/search?projectid=P-1234&page=2&per_page=50
+```
+
+### Supported Query Parameters
+
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|---------|
+| `projectid` | string or list | Filter by project ID(s) | `projectid=P-1234` or `projectid=P-1234&projectid=P-5678` |
+| `samplename` | string or list | Filter by sample name(s) | `samplename=Sample_001` |
+| `created_on` | string | Filter by creation date (YYYY-MM-DD) | `created_on=2026-01-21` |
+| `page` | integer | Page number (default: 1) | `page=2` |
+| `per_page` | integer | Results per page (default: 20) | `per_page=50` |
+| Any other key | string | Filter by custom attribute (case-insensitive key matching) | `Tissue=Liver` or `USUBJID=CA123012-01-234` |
+
+**Notes:**
+- Multiple values for the same parameter are OR'd together
+- Different parameters are AND'd together
+- Attribute key matching is case-insensitive (e.g., `tissue`, `Tissue`, `TISSUE` all match)
+- Date filtering matches all samples created on that date
+
+---
+
+## POST: Search with JSON Body
+
+Use POST for complex filtering, especially when working with tags or programmatic queries.
+
+### Request Format
+
+```json
+{
+  "filter_on": {
+    "projectid": "P-1234",
+    "samplename": "Sample_001",
+    "created_on": "2026-01-21",
+    "tags": {
+      "USUBJID": "CA123012-01-234",
+      "Tissue": "Liver"
+    }
+  },
+  "page": 1,
+  "per_page": 20
+}
+```
+
+### Examples
+
+**Basic filter:**
+```bash
+curl -X POST http://localhost:8000/api/v1/samples/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{
+    "filter_on": {
+      "projectid": "P-1234"
+    },
+    "page": 1,
+    "per_page": 20
+  }'
+```
+
+**Filter by tags (custom attributes):**
+```bash
+curl -X POST http://localhost:8000/api/v1/samples/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{
+    "filter_on": {
+      "tags": {
+        "USUBJID": "CA123012-01-234",
+        "Tissue": "Liver"
+      }
+    }
+  }'
+```
+
+**Combined filters:**
+```bash
+curl -X POST http://localhost:8000/api/v1/samples/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{
+    "filter_on": {
+      "projectid": "P-1234",
+      "created_on": "2026-01-21",
+      "tags": {
+        "Tissue": "Liver"
+      }
+    },
+    "page": 1,
+    "per_page": 50
+  }'
+```
+
+**List values (OR logic):**
+```bash
+curl -X POST http://localhost:8000/api/v1/samples/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{
+    "filter_on": {
+      "projectid": ["P-1234", "P-5678"],
+      "tags": {
+        "Tissue": "Liver"
+      }
+    }
+  }'
+```
+
+### Filter Behavior
+
+| Filter Type | Behavior |
+|-------------|----------|
+| `projectid` | Exact match on project ID; list values are OR'd |
+| `samplename` | Exact match on sample name; list values are OR'd |
+| `created_on` | Date prefix match (YYYY-MM-DD format) |
+| `tags` | Each key/value pair matched against sample attributes; keys are case-insensitive |
+| Custom attributes | Any key not in the above list is treated as an attribute filter |
+| Multiple filters | Combined with AND logic |
+
+---
+
+## Unified Free-Text Search
+
+Search across projects, runs, and samples simultaneously using a single query string.
+
+### Endpoint
+
+```bash
+GET /api/v1/search?query=MySample
+```
+
+### Response Format
+
+```json
+{
+  "projects": {
+    "data": [...],
+    "total_items": 5,
+    ...
+  },
+  "runs": {
+    "data": [...],
+    "total_items": 3,
+    ...
+  },
+  "samples": {
+    "data": [
+      {
+        "sample_id": "MySample_001",
+        "project_id": "P-1234",
+        "attributes": [...]
+      }
+    ],
+    "total_items": 12,
+    ...
+  }
+}
+```
+
+### Examples
+
+**Search for a sample by name:**
+```bash
+GET /api/v1/search?query=MySample
+```
+
+**Search for samples in a project:**
+```bash
+GET /api/v1/search?query=P-1234
+```
+
+**Search with pagination:**
+```bash
+GET /api/v1/search?query=Sample&page=2&per_page=10
+```
+
+### Query Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `query` | string | Free-text search query | Required |
+| `page` | integer | Page number | 1 |
+| `per_page` | integer | Results per page (applied to each entity type) | 5 |
+| `sort_by` | string | Sort field | `sample_id` |
+| `sort_order` | string | Sort order (`asc` or `desc`) | `asc` |
+
+### Searchable Fields
+
+For samples, the unified search matches on:
+- `sample_id` - The sample name/identifier
+- `project_id` - The project ID the sample belongs to
+
+**Note:** Custom attributes are NOT searchable via unified search. Use structured search (`/api/v1/samples/search`) for attribute-level filtering.
+
+---
+
+## Authentication
+
+All sample search endpoints require authentication. Include a valid JWT token in the Authorization header:
+
+```bash
+curl -X GET http://localhost:8000/api/v1/samples/search?projectid=P-1234 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+---
+
+## Use Cases
+
+### Finding samples in a project
+
+**GET:**
+```bash
+GET /api/v1/samples/search?projectid=P-1234
+```
+
+**POST:**
+```json
+POST /api/v1/samples/search
+{
+  "filter_on": {
+    "projectid": "P-1234"
+  }
+}
+```
+
+### Finding samples with specific attributes
+
+```json
+POST /api/v1/samples/search
+{
+  "filter_on": {
+    "projectid": "P-1234",
+    "tags": {
+      "Tissue": "Liver",
+      "Disease": "Cancer"
+    }
+  }
+}
+```
+
+### Finding samples created on a specific date
+
+```bash
+GET /api/v1/samples/search?created_on=2026-01-21&projectid=P-1234
+```
+
+### Finding samples across multiple projects
+
+```json
+POST /api/v1/samples/search
+{
+  "filter_on": {
+    "projectid": ["P-1234", "P-5678", "P-9999"]
+  }
+}
+```
+
+### Quick search across all entity types
+
+```bash
+GET /api/v1/search?query=Sample_001
+```
+
+---
+
+## Related Endpoints
+
+- `POST /api/v1/samples/reindex` - Rebuild the OpenSearch index for samples (admin only)
+- `GET /api/v1/projects/{project_id}/samples` - List all samples in a project
+- `POST /api/v1/projects/{project_id}/samples` - Create a new sample
+
+---
+
+## Error Responses
+
+**400 Bad Request** - Invalid query parameters or request body
+```json
+{
+  "detail": "Invalid date format for created_on. Use YYYY-MM-DD."
+}
+```
+
+**401 Unauthorized** - Missing or invalid authentication token
+```json
+{
+  "detail": "Not authenticated"
+}
+```
+
+**422 Unprocessable Entity** - Validation error
+```json
+{
+  "detail": [
+    {
+      "loc": ["body", "page"],
+      "msg": "ensure this value is greater than 0",
+      "type": "value_error"
+    }
+  ]
+}
+```
+
+---
+
+## Best Practices
+
+1. **Use POST for complex queries** - When filtering by multiple attributes or working programmatically, POST is cleaner than encoding everything in query params
+2. **Use GET for simple queries** - For quick, human-readable filters (e.g., bookmarkable URLs)
+3. **Leverage `data_cols`** - The response includes all attribute keys found in results, useful for building dynamic UI tables
+4. **Page large result sets** - Use pagination to avoid loading too much data at once
+5. **Use unified search for exploration** - When users are searching across entity types, `/api/v1/search` is faster than multiple calls
+6. **Use structured search for precision** - When you need exact attribute matching or complex filters, use `/api/v1/samples/search`

--- a/docs/SAMPLES_SEARCH.md
+++ b/docs/SAMPLES_SEARCH.md
@@ -346,12 +346,39 @@ POST /api/v1/samples/search
 GET /api/v1/search?query=Sample_001
 ```
 
----
-
 ## Related Endpoints
 
+### Sample Listing (Non-Search)
+
+For listing all samples in a project, use the standard project-samples endpoint:
+
+**`GET /api/v1/projects/{project_id}/samples`**
+
+This endpoint uses **offset-based pagination** (different from search endpoints):
+
+```json
+{
+  "data": [...],
+  "data_cols": [...],
+  "total_items": 100,
+  "skip": 0,
+  "limit": 100,
+  "has_next": false,
+  "has_prev": false
+}
+```
+
+**Query Parameters:**
+- `skip` - Number of items to skip (default: 0)
+- `limit` - Maximum items to return (default: 100)
+- `include_files` - Include file associations (optional)
+- `file_versions` - Return `all` file versions or `latest` only (optional)
+
+**Note:** The listing endpoint uses `skip`/`limit` (offset-based), while search endpoints use `page`/`per_page` (page-based). This distinction is intentional and aligns with the different use cases.
+
+### Other Related Endpoints
+
 - `POST /api/v1/samples/reindex` - Rebuild the OpenSearch index for samples (admin only)
-- `GET /api/v1/projects/{project_id}/samples` - List all samples in a project
 - `POST /api/v1/projects/{project_id}/samples` - Create a new sample
 
 ---

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -27,8 +27,9 @@ def test_get_samples_for_a_project_with_no_samples(
         "data": [],
         "data_cols": None,
         "total_items": 0,
-        "skip": 0,
-        "limit": 100,
+        "total_pages": 0,
+        "current_page": 1,
+        "per_page": 100,
         "has_next": False,
         "has_prev": False,
     }
@@ -505,8 +506,9 @@ def test_get_samples_include_files_pagination_works(
 
     data = response.json()
     assert data["total_items"] == 5
-    assert data["limit"] == 2
-    assert data["skip"] == 0
+    assert data["per_page"] == 2
+    assert data["current_page"] == 1
+    assert data["total_pages"] == 3
     assert data["has_next"] is True
     assert len(data["data"]) == 2
 

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -27,9 +27,8 @@ def test_get_samples_for_a_project_with_no_samples(
         "data": [],
         "data_cols": None,
         "total_items": 0,
-        "total_pages": 0,
-        "current_page": 1,
-        "per_page": 100,
+        "skip": 0,
+        "limit": 100,
         "has_next": False,
         "has_prev": False,
     }
@@ -506,9 +505,8 @@ def test_get_samples_include_files_pagination_works(
 
     data = response.json()
     assert data["total_items"] == 5
-    assert data["per_page"] == 2
-    assert data["current_page"] == 1
-    assert data["total_pages"] == 3
+    assert data["limit"] == 2
+    assert data["skip"] == 0
     assert data["has_next"] is True
     assert len(data["data"]) == 2
 

--- a/tests/api/test_samples_search.py
+++ b/tests/api/test_samples_search.py
@@ -1,0 +1,438 @@
+"""
+Tests for v1 /api/v1/samples/search endpoints.
+
+These tests verify that structured filtering works with v1 response format
+(SamplesPublic) instead of legacy format (LegacySampleSearchResponse).
+"""
+
+from sqlmodel import Session
+from fastapi.testclient import TestClient
+from datetime import datetime, timezone
+
+from api.project.models import Project
+from api.samples.models import Sample, SampleAttribute
+from api.project.services import generate_project_id
+
+
+def _create_project(session: Session, name: str = "Test Project") -> Project:
+    """Helper to create a project."""
+    project = Project(name=name)
+    project.project_id = generate_project_id(session=session)
+    project.attributes = []
+    session.add(project)
+    session.flush()
+    return project
+
+
+def _create_sample(
+    session: Session,
+    project: Project,
+    sample_id: str,
+    attributes: dict | None = None,
+    created_at: datetime | None = None,
+) -> Sample:
+    """Helper to create a sample with optional attributes."""
+    sample = Sample(
+        sample_id=sample_id,
+        project_id=project.project_id,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    session.add(sample)
+    session.flush()
+
+    if attributes:
+        for key, value in attributes.items():
+            attr = SampleAttribute(sample_id=sample.id, key=key, value=value)
+            session.add(attr)
+
+    session.flush()
+    return sample
+
+
+# ──────────────────────────────────────────────────────────────────
+# GET /api/v1/samples/search
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestV1GetSearch:
+    """Tests for GET /api/v1/samples/search"""
+
+    def test_search_by_projectid(self, client: TestClient, session: Session):
+        """Search by projectid returns matching samples in v1 format."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {"Tissue": "Liver"})
+        _create_sample(session, project, "S2", {"Tissue": "Heart"})
+        session.commit()
+
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"projectid": project.project_id},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        # V1 response format
+        assert data["total_items"] == 2
+        assert len(data["data"]) == 2
+        assert "current_page" in data
+        assert "per_page" in data
+        assert "has_next" in data
+        assert "has_prev" in data
+
+        # Each sample has v1 shape
+        for sample in data["data"]:
+            assert "sample_id" in sample
+            assert "project_id" in sample
+            assert "attributes" in sample
+            assert sample["project_id"] == project.project_id
+
+    def test_search_by_samplename(self, client: TestClient, session: Session):
+        """Search by samplename returns the matching sample."""
+        project = _create_project(session)
+        _create_sample(session, project, "MySample", {"Tissue": "Liver"})
+        _create_sample(session, project, "Other", {"Tissue": "Heart"})
+        session.commit()
+
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"samplename": "MySample"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 1
+        assert data["data"][0]["sample_id"] == "MySample"
+
+    def test_combined_search(self, client: TestClient, session: Session):
+        """Combined projectid + samplename returns intersection."""
+        p1 = _create_project(session, "P1")
+        p2 = _create_project(session, "P2")
+        _create_sample(session, p1, "SharedName")
+        _create_sample(session, p2, "SharedName")
+        session.commit()
+
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"projectid": p1.project_id, "samplename": "SharedName"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 1
+        assert data["data"][0]["project_id"] == p1.project_id
+
+    def test_search_by_attribute_as_query_param(
+        self, client: TestClient, session: Session
+    ):
+        """Unknown query params are searched as attributes (case-insensitive key)."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {"ASSAY_METHOD": "RNA-Seq"})
+        _create_sample(session, project, "S2", {"ASSAY_METHOD": "WES"})
+        session.commit()
+
+        # lowercase key should match uppercase attribute
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"assay_method": "RNA-Seq"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 1
+        assert data["data"][0]["sample_id"] == "S1"
+
+    def test_search_by_created_on(self, client: TestClient, session: Session):
+        """Search by created_on matches date prefix of created_at."""
+        project = _create_project(session)
+        _create_sample(
+            session, project, "S1",
+            created_at=datetime(2026, 1, 21, 10, 30, 0, tzinfo=timezone.utc),
+        )
+        _create_sample(
+            session, project, "S2",
+            created_at=datetime(2026, 1, 22, 10, 30, 0, tzinfo=timezone.utc),
+        )
+        session.commit()
+
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"created_on": "2026-01-21"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 1
+        assert data["data"][0]["sample_id"] == "S1"
+
+    def test_empty_results(self, client: TestClient, session: Session):
+        """Non-matching query returns empty results."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        session.commit()
+
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"projectid": "nonexistent"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 0
+        assert data["data"] == []
+
+    def test_no_params_returns_all(self, client: TestClient, session: Session):
+        """GET with no params returns all samples."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        _create_sample(session, project, "S2")
+        session.commit()
+
+        response = client.get("/api/v1/samples/search")
+        assert response.status_code == 200
+        assert response.json()["total_items"] == 2
+
+    def test_get_pagination(self, client: TestClient, session: Session):
+        """GET with page and per_page returns paginated results."""
+        project = _create_project(session)
+        for i in range(5):
+            _create_sample(session, project, f"S{i}")
+        session.commit()
+
+        # Page 1, per_page=2
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"projectid": project.project_id, "page": 1, "per_page": 2},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 5
+        assert data["current_page"] == 1
+        assert data["per_page"] == 2
+        assert len(data["data"]) == 2
+        assert data["has_next"] is True
+        assert data["has_prev"] is False
+
+        # Page 3, per_page=2 — should get 1 result
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"projectid": project.project_id, "page": 3, "per_page": 2},
+        )
+        data = response.json()
+        assert data["total_items"] == 5
+        assert len(data["data"]) == 1
+        assert data["has_next"] is False
+        assert data["has_prev"] is True
+
+    def test_data_cols_populated(self, client: TestClient, session: Session):
+        """Verify data_cols is populated from matching samples' attributes."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {"Tissue": "Liver", "Method": "RNA-Seq"})
+        _create_sample(session, project, "S2", {"Tissue": "Heart"})
+        session.commit()
+
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"projectid": project.project_id},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["data_cols"] is not None
+        assert "Tissue" in data["data_cols"]
+        assert "Method" in data["data_cols"]
+
+    def test_attributes_in_v1_format(self, client: TestClient, session: Session):
+        """Verify attributes are returned as list of {key, value} dicts."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {
+            "Tissue": "Liver",
+            "ASSAY_METHOD": "RNA-Seq",
+        })
+        session.commit()
+
+        response = client.get(
+            "/api/v1/samples/search",
+            params={"projectid": project.project_id},
+        )
+        assert response.status_code == 200
+        sample = response.json()["data"][0]
+        assert isinstance(sample["attributes"], list)
+        attr_keys = [a["key"] for a in sample["attributes"]]
+        assert "Tissue" in attr_keys
+        assert "ASSAY_METHOD" in attr_keys
+
+
+# ──────────────────────────────────────────────────────────────────
+# POST /api/v1/samples/search
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestV1PostSearch:
+    """Tests for POST /api/v1/samples/search"""
+
+    def test_post_basic_filter(self, client: TestClient, session: Session):
+        """POST with projectid filter returns matching samples."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        _create_sample(session, project, "S2")
+        session.commit()
+
+        response = client.post(
+            "/api/v1/samples/search",
+            json={"filter_on": {"projectid": project.project_id}},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 2
+        assert data["current_page"] == 1
+        assert data["per_page"] == 20
+
+    def test_post_tag_filter(self, client: TestClient, session: Session):
+        """POST with tags filter matches attributes."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {"USUBJID": "CA123-01"})
+        _create_sample(session, project, "S2", {"USUBJID": "CA123-02"})
+        session.commit()
+
+        response = client.post(
+            "/api/v1/samples/search",
+            json={
+                "filter_on": {
+                    "tags": {"USUBJID": "CA123-01"},
+                },
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 1
+        assert data["data"][0]["sample_id"] == "S1"
+
+    def test_post_combined_filter(self, client: TestClient, session: Session):
+        """POST with projectid + tags combined."""
+        p1 = _create_project(session, "P1")
+        p2 = _create_project(session, "P2")
+        _create_sample(session, p1, "S1", {"USUBJID": "CA123-01"})
+        _create_sample(session, p2, "S2", {"USUBJID": "CA123-01"})
+        session.commit()
+
+        response = client.post(
+            "/api/v1/samples/search",
+            json={
+                "filter_on": {
+                    "projectid": p1.project_id,
+                    "tags": {"USUBJID": "CA123-01"},
+                },
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 1
+        assert data["data"][0]["project_id"] == p1.project_id
+
+    def test_post_list_values_or(self, client: TestClient, session: Session):
+        """POST with list values for projectid matches any (OR)."""
+        p1 = _create_project(session, "P1")
+        p2 = _create_project(session, "P2")
+        p3 = _create_project(session, "P3")
+        _create_sample(session, p1, "S1")
+        _create_sample(session, p2, "S2")
+        _create_sample(session, p3, "S3")
+        session.commit()
+
+        response = client.post(
+            "/api/v1/samples/search",
+            json={
+                "filter_on": {
+                    "projectid": [p1.project_id, p2.project_id],
+                },
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 2
+
+    def test_post_pagination(self, client: TestClient, session: Session):
+        """POST respects page and per_page, total is full count."""
+        project = _create_project(session)
+        for i in range(5):
+            _create_sample(session, project, f"S{i}")
+        session.commit()
+
+        # Page 1, per_page=2
+        response = client.post(
+            "/api/v1/samples/search",
+            json={
+                "filter_on": {"projectid": project.project_id},
+                "page": 1,
+                "per_page": 2,
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 5
+        assert data["current_page"] == 1
+        assert data["per_page"] == 2
+        assert len(data["data"]) == 2
+        assert data["has_next"] is True
+
+        # Page 3, per_page=2 — should get 1 result
+        response = client.post(
+            "/api/v1/samples/search",
+            json={
+                "filter_on": {"projectid": project.project_id},
+                "page": 3,
+                "per_page": 2,
+            },
+        )
+        data = response.json()
+        assert data["total_items"] == 5
+        assert len(data["data"]) == 1
+        assert data["has_next"] is False
+        assert data["has_prev"] is True
+
+    def test_post_case_insensitive_tag_keys(
+        self, client: TestClient, session: Session
+    ):
+        """POST tag search is case-insensitive on keys."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1", {"ASSAY_METHOD": "RNA-Seq"})
+        session.commit()
+
+        # lowercase key should match uppercase attribute
+        response = client.post(
+            "/api/v1/samples/search",
+            json={
+                "filter_on": {
+                    "tags": {"assay_method": "RNA-Seq"},
+                },
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["total_items"] == 1
+
+    def test_post_empty_filter_returns_all(
+        self, client: TestClient, session: Session
+    ):
+        """POST with empty filter_on returns all samples."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        _create_sample(session, project, "S2")
+        session.commit()
+
+        response = client.post(
+            "/api/v1/samples/search",
+            json={"filter_on": {}},
+        )
+        assert response.status_code == 200
+        assert response.json()["total_items"] == 2
+
+    def test_post_empty_body_uses_defaults(
+        self, client: TestClient, session: Session
+    ):
+        """POST with minimal body uses defaults for page and per_page."""
+        project = _create_project(session)
+        _create_sample(session, project, "S1")
+        session.commit()
+
+        response = client.post(
+            "/api/v1/samples/search",
+            json={},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["current_page"] == 1
+        assert data["per_page"] == 20

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -198,15 +198,15 @@ def test_search(client: TestClient, opensearch_client: OpenSearch):
     Test unified search endpoint for search bar that
     returns a response model for each index in OpenSearch.
 
-    For example, if projects and runs both exist, then the return
+    For example, if projects, runs, and samples all exist, then the return
     structure should be
 
     SearchResponse:
         projects: ProjectsPublic
         runs: SequencingRunsPublic
+        samples: SamplesPublic
 
-    where ProjectsPublic is returned by the get projects endpoint and
-    SequencingRunsPublic is returned by the get runs endpoint.
+    where each is the paginated public model for that entity type.
 
     Each new index should append another prop to this SearchResponse.
     """
@@ -223,15 +223,17 @@ def test_search(client: TestClient, opensearch_client: OpenSearch):
     assert response.status_code == 200
     response_json = response.json()
 
-    # Has projects and runs indicies (even if no data is returned)
+    # Has projects, runs, and samples indices (even if no data is returned)
     assert "projects" in response_json
     assert "runs" in response_json
+    assert "samples" in response_json
 
     # Data is returned (update runs when populated)
     assert response_json["projects"]["data"]
     assert response_json["runs"]["data"] == []
     projects = response_json["projects"]
     runs = response_json["runs"]
+    samples = response_json["samples"]
 
     # Project structure
     assert projects["data"][0]["name"] == "Test project 1"
@@ -251,3 +253,12 @@ def test_search(client: TestClient, opensearch_client: OpenSearch):
     assert runs["per_page"] == 5
     assert runs["has_next"] is False
     assert runs["has_prev"] is False
+
+    # Sample structure (no samples created, so empty)
+    assert len(samples["data"]) == 0
+    assert samples["total_items"] == 0
+    assert samples["total_pages"] == 0
+    assert samples["current_page"] == 1
+    assert samples["per_page"] == 5
+    assert samples["has_next"] is False
+    assert samples["has_prev"] is False


### PR DESCRIPTION
This implements seach functionality for sample entities which is needed for downstream consumers of our sample records. the /api/v1/samples/search endpoint allows users to search for samples by exact criteria such as name, creation dates, and attributes.

i also updated the free-text generic search to query also samples in addition to projects and runs; however, since the sample results are in their own new key, this will be ignored by the frontend search bar which only returns projects and runs (https://github.com/NGS360/frontend-ui/blob/20430dc4c7ddab652cff390d6a891381380c2fa5/src/components/search-bar.tsx#L83)