### PR TITLE
swtich sbg create project to email

### DIFF
--- a/api/project/routes.py
+++ b/api/project/routes.py
@@ -487,6 +487,7 @@ def submit_pipeline_job(
         platform=request.platform,
         project_type=request.project_type,
         username=current_user.username,
+        email=current_user.email,
         reference=request.reference,
         auto_release=request.auto_release,
         s3_client=s3_client

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -523,6 +523,7 @@ def submit_pipeline_job(
     platform: "ActionPlatform",
     project_type: str,
     username: str,
+    email: str | None = None,
     reference: str | None = None,
     auto_release: bool | None = None,
     s3_client=None
@@ -541,6 +542,7 @@ def submit_pipeline_job(
         platform: Platform name (arvados or sevenbridges)
         project_type: Pipeline type (e.g., RNA-Seq)
         username: Username of the user submitting the job
+        email: Email of the user submitting the job (available as template variable)
         reference: Export reference label (required for export action)
         auto_release: Auto-release flag (only valid for export action)
         s3_client: Optional boto3 S3 client
@@ -627,6 +629,7 @@ def submit_pipeline_job(
     # Prepare template context with all variables needed for interpolation
     template_context = {
         "username": username,
+        "email": email,
         "projectid": project.project_id,
         "project_type": project_type,
         "platform": platform.value,


### PR DESCRIPTION
This PR addresses #293 with the following changes:
1. Adds the user email to the pipeline job submission function, which adds it to the template context. That way, when the backend command for the BMS package is constructed, the email can be filled in instead of the username. 

Note:
* the tool config for the SBG create project will have to be changed from `{{username}}` to `{{email}}`
* confirmed that the backend package works with email as the `--owner` parameter. 