### PR TITLE
Tolerate samplesheets with utf 8 bom encoding

### DIFF
--- a/api/runs/services.py
+++ b/api/runs/services.py
@@ -313,7 +313,10 @@ def get_run_samplesheet(session: Session, run_id: str):
     if run.run_folder_uri:
         sample_sheet_path = f"{run.run_folder_uri}/SampleSheet.csv"
         try:
-            sample_sheet = IlluminaSampleSheet(sample_sheet_path)
+            # Open with utf-8-sig so a leading UTF-8 BOM is stripped before
+            # the samplesheet is parsed if present
+            with smart_open(sample_sheet_path, 'r', encoding='utf-8-sig') as f:
+                sample_sheet = IlluminaSampleSheet(f)
             sample_sheet = sample_sheet.to_json()
             sample_sheet = json.loads(sample_sheet)
             sample_sheet_json['Header'] = sample_sheet['Header']
@@ -465,7 +468,10 @@ def upload_samplesheet(
 
     # After successful upload, read back the samplesheet to return its content
     try:
-        sample_sheet = IlluminaSampleSheet(samplesheet_path)
+        # Open with utf-8-sig so a leading UTF-8 BOM is stripped before
+        # the samplesheet is parsed (some Windows tools emit a BOM).
+        with smart_open(samplesheet_path, 'r', encoding='utf-8-sig') as f:
+            sample_sheet = IlluminaSampleSheet(f)
         sample_sheet = sample_sheet.to_json()
         sample_sheet = json.loads(sample_sheet)
         sample_sheet_json = {

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -525,6 +525,38 @@ def test_get_run_samplesheet(client: TestClient, session: Session):
     assert "id" not in data["Summary"]  # Database ID should not be exposed
 
 
+def test_get_run_samplesheet_with_bom(client: TestClient, session: Session):
+    """A samplesheet encoded with a UTF-8 BOM should still parse correctly."""
+
+    # This fixture's SampleSheet.csv is encoded utf-8-sig (leading BOM)
+    run_folder = (
+        Path(__file__).parent.parent / "fixtures" / "190110_MACHINE123_0003_BOMFLOWCELL"
+    )
+
+    new_run = SequencingRun(
+        id=uuid4(),
+        run_id="190110_MACHINE123_0003_BOMFLOWCELL",
+        run_date=datetime.date(2019, 1, 10),
+        machine_id="MACHINE123",
+        run_number="3",
+        flowcell_id="BOMFLOWCELL",
+        experiment_name="Test Experiment",
+        run_folder_uri=run_folder.as_posix(),
+        status=RunStatus.READY,
+    )
+    session.add(new_run)
+    session.commit()
+
+    run_id = "190110_MACHINE123_0003_BOMFLOWCELL"
+    response = client.get(f"/api/v1/runs/{run_id}/samplesheet")
+    assert response.status_code == 200
+    data = response.json()
+    # The BOM must not leak into the first parsed Header key/section
+    assert "Header" in data
+    assert data["Header"]
+    assert not any(key.startswith("﻿") for key in data["Header"])
+
+
 def test_get_run_samplesheet_no_result(client: TestClient, session: Session):
     """Test that we get the correct response when no samplesheet is available"""
 
@@ -554,14 +586,14 @@ def test_get_run_samplesheet_no_result(client: TestClient, session: Session):
     assert response.status_code == 204
 
 
-@patch('api.runs.services.IlluminaSampleSheet')
+@patch('api.runs.services.smart_open')
 def test_get_run_samplesheet_no_s3_credentials(
-    mock_sample_sheet, client: TestClient, session: Session
+    mock_smart_open, client: TestClient, session: Session
 ):
     """Test that we get the correct response when no AWS credentials are configured"""
 
-    # Mock the SampleSheet to raise NoCredentialsError
-    mock_sample_sheet.side_effect = NoCredentialsError()
+    # Mock opening the samplesheet to raise NoCredentialsError
+    mock_smart_open.side_effect = NoCredentialsError()
 
     # Set the test run folder to an S3 path
     run_folder = "s3://bucket/path/to/run"

--- a/tests/fixtures/190110_MACHINE123_0003_BOMFLOWCELL/SampleSheet.csv
+++ b/tests/fixtures/190110_MACHINE123_0003_BOMFLOWCELL/SampleSheet.csv
@@ -1,0 +1,24 @@
+﻿[Header]
+IEMFileVersion,4
+Investigator Name,Jane Smith
+Experiment Name,Test Experiment
+Date,1/10/2019
+Workflow,GenerateFASTQ
+Application,FASTQ Only
+Assay,TruSeq HT
+Description,Test sequencing run
+Chemistry,Amplicon
+
+[Reads]
+151
+151
+
+[Settings]
+ReverseComplement,0
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Sample_1,Sample_1,,,N701,TAAGGCGA,S501,TAGATCGC,TestProject,Test sample 1
+Sample_2,Sample_2,,,N702,CGTACTAG,S502,CTCTCTAT,TestProject,Test sample 2
+


### PR DESCRIPTION
Many tools/systems write out a UTF-8 with a Byte Order Marking, including Excel in CSV UTF-8 mode. However, if utf-8 encoding is used to read these files, IlluminaSampleSheet throws an error like:
"ValueError: Sample sheet contains invalid characters on line 1: ï»¿[Header]”
(this is especially hard for users to troubleshoot as many tools correctly ignore this BOM so the header appears correct on visual inspection)

This PR opens the samplesheet with utf-8-sig encoding (which handles both utf-8 or utf-8-bom) and passes the file handle rather than the path to IlluminaSampleSheet constructor to avoid the error.