### PR TITLE
Omics workflow deployment through lambda function

### DIFF
--- a/api/workflow/models.py
+++ b/api/workflow/models.py
@@ -206,7 +206,7 @@ class WorkflowVersionAliasPublic(SQLModel):
 
 class WorkflowDeploymentCreate(SQLModel):
     engine: str
-    external_id: str
+    external_id: str | None = None
 
 
 class WorkflowDeploymentPublic(SQLModel):

--- a/api/workflow/services.py
+++ b/api/workflow/services.py
@@ -4,8 +4,11 @@ Workflow Service
 CRUD operations for Workflow, WorkflowVersion, WorkflowVersionAlias,
 and WorkflowDeployment entities.
 """
+import json
 from uuid import UUID
 
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError
 from fastapi import HTTPException, status
 from sqlmodel import Session, select
 from sqlalchemy import func
@@ -30,6 +33,8 @@ from api.workflow.models import (
     WorkflowVersionAliasPublic,
     WorkflowVersionAliasSet,
 )
+from core.config import get_settings
+from core.logger import logger
 
 
 # ---------------------------------------------------------------------------
@@ -460,6 +465,156 @@ def alias_to_public(
 # WorkflowDeployment CRUD
 # ---------------------------------------------------------------------------
 
+def _find_existing_omics_deployment(
+    session: Session,
+    workflow: Workflow,
+    engine: str,
+) -> WorkflowDeployment | None:
+    """Return the most recent Omics deployment for this Workflow, if any.
+
+    Used to decide between Lambda action `create_workflow` (first time on Omics)
+    and `create_workflow_version` (workflow already registered on Omics).
+    """
+    return session.exec(
+        select(WorkflowDeployment)
+        .join(WorkflowVersion)
+        .where(
+            WorkflowVersion.workflow_id == workflow.id,
+            WorkflowDeployment.engine == engine,
+        )
+        .order_by(WorkflowVersion.version.desc())
+    ).first()
+
+
+def _invoke_omics_register_lambda(payload: dict) -> dict:
+    """Invoke the Omics workflow-registration Lambda and return parsed body."""
+    settings = get_settings()
+    function_name = settings.OMICS_REGISTER_WORKFLOW_LAMBDA
+    if not function_name:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                "OMICS_REGISTER_WORKFLOW_LAMBDA is not configured. "
+                "Set the env var to the Lambda function name."
+            ),
+        )
+
+    logger.info(
+        "Invoking Omics-register Lambda '%s' with action=%s",
+        function_name,
+        payload.get("action"),
+    )
+
+    try:
+        lambda_client = boto3.client("lambda", region_name=settings.AWS_REGION)
+        response = lambda_client.invoke(
+            FunctionName=function_name,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(payload),
+        )
+    except NoCredentialsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="AWS credentials not found. Cannot invoke Omics Lambda.",
+        ) from exc
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        msg = exc.response["Error"]["Message"]
+        logger.error("Omics Lambda ClientError: %s - %s", code, msg)
+        if code == "ResourceNotFoundException":
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Lambda function not found: {function_name}",
+            ) from exc
+        if code == "AccessDeniedException":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Access denied to Lambda function: {function_name}",
+            ) from exc
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Lambda error: {msg}",
+        ) from exc
+
+    body = json.loads(response["Payload"].read().decode("utf-8"))
+    logger.debug("Omics Lambda response: %s", body)
+
+    if "FunctionError" in response:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                f"Omics Lambda execution error: "
+                f"{body.get('errorMessage', 'unknown')}"
+            ),
+        )
+
+    if body.get("statusCode") and body["statusCode"] >= 400:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                f"Omics registration failed: "
+                f"{body.get('message') or body.get('error') or body}"
+            ),
+        )
+
+    arn = body.get("arn")
+    if not arn:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                "Omics Lambda did not return an 'arn' field. "
+                f"Response: {body}"
+            ),
+        )
+
+    return body
+
+
+def _register_workflow_on_omics(
+    session: Session,
+    workflow: Workflow,
+    version: WorkflowVersion,
+    engine: str,
+) -> str:
+    """Register the workflow/version on AWS HealthOmics via Lambda; return ARN."""
+    prior = _find_existing_omics_deployment(session, workflow, engine)
+
+    if prior is None:
+        payload = {
+            "source": "ngs360",
+            "action": "create_workflow",
+            "name": workflow.name,
+            "cwl_s3_path": version.definition_uri,
+            "id": str(version.id),
+        }
+    else:
+        # Reuse the omics workflow id from the prior deployment's ARN.
+        # ARN format: arn:aws:omics:<region>:<acct>:workflow/<id>/version/<name>
+        try:
+            omics_workflow_id = (
+                prior.external_id.split(":workflow/")[1].split("/")[0]
+            )
+        except (IndexError, AttributeError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    f"Could not parse Omics workflow id from prior "
+                    f"deployment external_id '{prior.external_id}'."
+                ),
+            ) from exc
+        payload = {
+            "source": "ngs360",
+            "action": "create_workflow_version",
+            "omics_workflow_id": omics_workflow_id,
+            "version_name": str(version.id),
+            "cwl_s3_path": version.definition_uri,
+            "id": str(version.id),
+        }
+
+    body = _invoke_omics_register_lambda(payload)
+    return body["arn"]
+
+
 def create_workflow_deployment(
     session: Session,
     workflow_id: str,
@@ -467,7 +622,13 @@ def create_workflow_deployment(
     deployment_in: WorkflowDeploymentCreate,
     created_by: str,
 ) -> WorkflowDeployment:
-    """Deploy a workflow version on a specific platform."""
+    """Deploy a workflow version on a specific platform.
+
+    If the caller supplies ``external_id`` we trust it and store as-is.
+    Otherwise, for engine ``AWSHealthOmics (us-east)`` the API server
+    registers the workflow on AWS HealthOmics via a Lambda and stores the
+    returned ARN. For other engines the caller must provide ``external_id``.
+    """
     # Verify version exists and belongs to this workflow
     version = get_workflow_version_by_num(session, workflow_id, version_num)
 
@@ -490,10 +651,25 @@ def create_workflow_deployment(
             ),
         )
 
+    if deployment_in.external_id:
+        external_id = deployment_in.external_id
+    elif deployment_in.engine == "AWSHealthOmics (us-east)":
+        external_id = _register_workflow_on_omics(
+            session, version.workflow, version, deployment_in.engine,
+        )
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"external_id is required for engine "
+                f"'{deployment_in.engine}'."
+            ),
+        )
+
     deployment = WorkflowDeployment(
         workflow_version_id=version.id,
         engine=deployment_in.engine,
-        external_id=deployment_in.external_id,
+        external_id=external_id,
         created_by=created_by,
     )
 

--- a/api/workflow/services.py
+++ b/api/workflow/services.py
@@ -470,7 +470,7 @@ def _find_existing_omics_deployment(
     workflow: Workflow,
     engine: str,
 ) -> WorkflowDeployment | None:
-    """Return the most recent Omics deployment for this Workflow, if any.
+    """Return the first Omics deployment for this Workflow, if any.
 
     Used to decide between Lambda action `create_workflow` (first time on Omics)
     and `create_workflow_version` (workflow already registered on Omics).
@@ -482,7 +482,7 @@ def _find_existing_omics_deployment(
             WorkflowVersion.workflow_id == workflow.id,
             WorkflowDeployment.engine == engine,
         )
-        .order_by(WorkflowVersion.version.desc())
+        .order_by(WorkflowVersion.version.asc())
     ).first()
 
 

--- a/api/workflow/services.py
+++ b/api/workflow/services.py
@@ -585,7 +585,7 @@ def _register_workflow_on_omics(
             "action": "create_workflow",
             "name": workflow.name,
             "cwl_s3_path": version.definition_uri,
-            "id": str(version.id),
+            "id": str(version.workflow_id),
         }
     else:
         # Reuse the omics workflow id from the prior deployment's ARN.
@@ -606,9 +606,9 @@ def _register_workflow_on_omics(
             "source": "ngs360",
             "action": "create_workflow_version",
             "omics_workflow_id": omics_workflow_id,
-            "version_name": str(version.id),
+            "version_name": str(version.version),
             "cwl_s3_path": version.definition_uri,
-            "id": str(version.id),
+            "id": str(version.workflow_id),
         }
 
     body = _invoke_omics_register_lambda(payload)

--- a/core/config.py
+++ b/core/config.py
@@ -167,6 +167,12 @@ class Settings(BaseSettings):
         """Get AWS Region from env or secrets (defaults to us-east-1)"""
         return self._get_config_value("AWS_REGION", default="us-east-1")
 
+    @computed_field
+    @property
+    def OMICS_REGISTER_WORKFLOW_LAMBDA(self) -> str | None:
+        """Lambda function name that registers a workflow on AWS HealthOmics."""
+        return self._get_config_value("OMICS_REGISTER_WORKFLOW_LAMBDA")
+
     # Options are from api.files.models.StorageBackend
     STORAGE_BACKEND: str = os.getenv("STORAGE_BACKEND", "s3")
     STORAGE_ROOT_PATH: str = os.getenv("STORAGE_URI", "s3://my-storage-bucket")

--- a/tests/api/test_workflow_deployments.py
+++ b/tests/api/test_workflow_deployments.py
@@ -627,10 +627,10 @@ def test_omics_deployment_second_version_uses_create_version(
     assert mock_lambda_client.invocations == []  # caller supplied → no Lambda
 
     # Now deploy v2 without external_id → Lambda is invoked, action=create_workflow_version
-    v2_arn = f"{OMICS_ARN_PREFIX}workflow/9999999/version/{v2.id}"
+    v2_arn = f"{OMICS_ARN_PREFIX}workflow/9999999/version/2"
     mock_lambda_client.set_response({
         "statusCode": 200,
-        "version_name": str(v2.id),
+        "version_name": "2",
         "omics_workflow_id": "9999999",
         "arn": v2_arn,
     })
@@ -643,7 +643,7 @@ def test_omics_deployment_second_version_uses_create_version(
     inv = mock_lambda_client.invocations[-1]
     assert inv["Payload"]["action"] == "create_workflow_version"
     assert inv["Payload"]["omics_workflow_id"] == "9999999"
-    assert inv["Payload"]["version_name"] == str(v2.id)
+    assert inv["Payload"]["version_name"] == "2"
     assert inv["Payload"]["cwl_s3_path"] == "s3://b/v2.cwl"
 
 

--- a/tests/api/test_workflow_deployments.py
+++ b/tests/api/test_workflow_deployments.py
@@ -1,10 +1,12 @@
 """Tests for WorkflowDeployment CRUD endpoints."""
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from api.platforms.models import Platform
 from api.workflow.models import Workflow, WorkflowVersion
+from core.config import get_settings
 
 
 # ---------------------------------------------------------------------------
@@ -505,3 +507,235 @@ def test_workflow_deployments_engine_no_match_empty(
     )
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Omics auto-register flow
+# ---------------------------------------------------------------------------
+
+OMICS_ENGINE = "AWSHealthOmics (us-east)"
+OMICS_ARN_PREFIX = "arn:aws:omics:us-east-1:123456789012:"
+
+
+@pytest.fixture(name="omics_env")
+def omics_env_fixture(monkeypatch):
+    """Set OMICS_REGISTER_WORKFLOW_LAMBDA env + clear settings cache."""
+    monkeypatch.setenv(
+        "OMICS_REGISTER_WORKFLOW_LAMBDA", "test-omics-register-lambda",
+    )
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _seed_omics_platform(session: Session) -> None:
+    session.add(Platform(name=OMICS_ENGINE))
+    session.commit()
+
+
+def _create_cwl_workflow_and_version(
+    session: Session,
+) -> tuple[str, str, int]:
+    """Insert a workflow + CWL version; return (wf_id, version_uuid, version_num)."""
+    wf = Workflow(
+        name="CWL Alignment",
+        created_by="testuser",
+    )
+    session.add(wf)
+    session.flush()
+    ver = WorkflowVersion(
+        workflow_id=wf.id,
+        version=1,
+        definition_uri="s3://bucket/align.cwl",
+        created_by="testuser",
+    )
+    session.add(ver)
+    session.commit()
+    session.refresh(wf)
+    session.refresh(ver)
+    return str(wf.id), str(ver.id), ver.version
+
+
+def test_omics_deployment_first_version_registers_via_lambda(
+    client: TestClient, session: Session,
+    mock_lambda_client, omics_env,
+):
+    """First Omics deployment of a workflow uses action=create_workflow."""
+    _seed_omics_platform(session)
+    wf_id, ver_id, ver_num = _create_cwl_workflow_and_version(session)
+
+    arn = f"{OMICS_ARN_PREFIX}workflow/1324105/version/{ver_id}"
+    mock_lambda_client.set_response({
+        "statusCode": 200,
+        "workflow_id": "1324105",
+        "arn": arn,
+        "message": "Registered",
+    })
+
+    resp = client.post(
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}/deployments",
+        json={"engine": OMICS_ENGINE},
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["engine"] == OMICS_ENGINE
+    assert data["external_id"] == arn
+
+    # Lambda was invoked with create_workflow action
+    assert len(mock_lambda_client.invocations) == 1
+    inv = mock_lambda_client.invocations[0]
+    assert inv["FunctionName"] == "test-omics-register-lambda"
+    assert inv["Payload"]["action"] == "create_workflow"
+    assert inv["Payload"]["source"] == "ngs360"
+    assert inv["Payload"]["name"] == "CWL Alignment"
+    assert inv["Payload"]["cwl_s3_path"] == "s3://bucket/align.cwl"
+    assert inv["Payload"]["id"] == ver_id
+
+
+def test_omics_deployment_second_version_uses_create_version(
+    client: TestClient, session: Session,
+    mock_lambda_client, omics_env,
+):
+    """A Workflow that already has an Omics deployment uses create_workflow_version."""
+    _seed_omics_platform(session)
+
+    wf = Workflow(name="Multi", created_by="testuser")
+    session.add(wf)
+    session.flush()
+    v1 = WorkflowVersion(
+        workflow_id=wf.id, version=1,
+        definition_uri="s3://b/v1.cwl", created_by="testuser",
+    )
+    v2 = WorkflowVersion(
+        workflow_id=wf.id, version=2,
+        definition_uri="s3://b/v2.cwl", created_by="testuser",
+    )
+    session.add_all([v1, v2])
+    session.commit()
+    session.refresh(wf)
+    session.refresh(v1)
+    session.refresh(v2)
+    wf_id = str(wf.id)
+
+    # Seed an existing Omics deployment on v1 (caller-supplied external_id path)
+    v1_arn = f"{OMICS_ARN_PREFIX}workflow/9999999/version/{v1.id}"
+    resp1 = client.post(
+        f"/api/v1/workflows/{wf_id}/versions/1/deployments",
+        json={"engine": OMICS_ENGINE, "external_id": v1_arn},
+    )
+    assert resp1.status_code == 201, resp1.text
+    assert mock_lambda_client.invocations == []  # caller supplied → no Lambda
+
+    # Now deploy v2 without external_id → Lambda is invoked, action=create_workflow_version
+    v2_arn = f"{OMICS_ARN_PREFIX}workflow/9999999/version/{v2.id}"
+    mock_lambda_client.set_response({
+        "statusCode": 200,
+        "version_name": str(v2.id),
+        "omics_workflow_id": "9999999",
+        "arn": v2_arn,
+    })
+    resp2 = client.post(
+        f"/api/v1/workflows/{wf_id}/versions/2/deployments",
+        json={"engine": OMICS_ENGINE},
+    )
+    assert resp2.status_code == 201, resp2.text
+
+    inv = mock_lambda_client.invocations[-1]
+    assert inv["Payload"]["action"] == "create_workflow_version"
+    assert inv["Payload"]["omics_workflow_id"] == "9999999"
+    assert inv["Payload"]["version_name"] == str(v2.id)
+    assert inv["Payload"]["cwl_s3_path"] == "s3://b/v2.cwl"
+
+
+def test_omics_deployment_lambda_not_configured(
+    client: TestClient, session: Session, monkeypatch,
+):
+    """Without OMICS_REGISTER_WORKFLOW_LAMBDA set, Omics auto-register fails 500."""
+    _seed_omics_platform(session)
+    wf_id, _, ver_num = _create_cwl_workflow_and_version(session)
+
+    monkeypatch.delenv("OMICS_REGISTER_WORKFLOW_LAMBDA", raising=False)
+    get_settings.cache_clear()
+
+    resp = client.post(
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}/deployments",
+        json={"engine": OMICS_ENGINE},
+    )
+    assert resp.status_code == 500
+    assert "OMICS_REGISTER_WORKFLOW_LAMBDA" in resp.json()["detail"]
+
+
+def test_omics_deployment_lambda_returns_error_status(
+    client: TestClient, session: Session,
+    mock_lambda_client, omics_env,
+):
+    """Lambda error statusCode propagates as 502."""
+    _seed_omics_platform(session)
+    wf_id, _, ver_num = _create_cwl_workflow_and_version(session)
+
+    mock_lambda_client.set_response({
+        "statusCode": 500,
+        "error": "WorkflowRegistrationError",
+        "message": "ECR auth failed",
+    })
+
+    resp = client.post(
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}/deployments",
+        json={"engine": OMICS_ENGINE},
+    )
+    assert resp.status_code == 502
+    assert "ECR auth failed" in resp.json()["detail"]
+
+
+def test_omics_deployment_lambda_missing_arn(
+    client: TestClient, session: Session,
+    mock_lambda_client, omics_env,
+):
+    """Lambda success but no arn field returns 502."""
+    _seed_omics_platform(session)
+    wf_id, _, ver_num = _create_cwl_workflow_and_version(session)
+
+    mock_lambda_client.set_response({
+        "statusCode": 200,
+        "workflow_id": "1324105",
+    })
+
+    resp = client.post(
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}/deployments",
+        json={"engine": OMICS_ENGINE},
+    )
+    assert resp.status_code == 502
+    assert "arn" in resp.json()["detail"]
+
+
+def test_omics_deployment_with_explicit_external_id_skips_lambda(
+    client: TestClient, session: Session,
+    mock_lambda_client, omics_env,
+):
+    """Caller-supplied external_id is stored as-is; Lambda is not invoked."""
+    _seed_omics_platform(session)
+    wf_id, ver_id, ver_num = _create_cwl_workflow_and_version(session)
+
+    arn = f"{OMICS_ARN_PREFIX}workflow/4256500/version/{ver_id}"
+    resp = client.post(
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}/deployments",
+        json={"engine": OMICS_ENGINE, "external_id": arn},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["external_id"] == arn
+    assert mock_lambda_client.invocations == []
+
+
+def test_non_omics_deployment_without_external_id_400(
+    client: TestClient, session: Session,
+):
+    """Non-Omics engine without external_id is rejected 400."""
+    _seed_platforms(session)
+    wf_id, _, ver_num = _create_workflow_and_version(session)
+
+    resp = client.post(
+        f"/api/v1/workflows/{wf_id}/versions/{ver_num}/deployments",
+        json={"engine": "Arvados"},
+    )
+    assert resp.status_code == 400
+    assert "external_id is required" in resp.json()["detail"]


### PR DESCRIPTION
This PR includes changes to automatically register workflows on AWS HealthOmics when a deployment is created for engine="AWSHealthOmics (us-east)". The API server invokes the existing ngs360_event_handler Lambda and stores the returned workflow/version ARN as the deployment's external_id.

**Behavior**
external_id on POST /workflows/{id}/versions/{n}/deployments is now optional.
If the caller supplies external_id, it's stored as-is (existing behavior, unchanged for Arvados / SevenBridges).
If external_id is omitted and engine is AWSHealthOmics (us-east), the API invokes the Omics-register Lambda:
First deployment of a workflow on Omics → action create_workflow
Subsequent versions → action create_workflow_version, reusing the Omics workflow id parsed from initial deployment's ARN
Lambda function name comes from the new OMICS_REGISTER_WORKFLOW_LAMBDA env var (read via core.config.Settings).
Failure paths map to clear HTTP statuses: missing env var → 500; Lambda not found → 404; access denied → 403; Lambda returns error / missing arn → 502.

**Files**
[api/workflow/models.py] — WorkflowDeploymentCreate.external_id now optional.
[api/workflow/services.py] — Omics auto-register branch + Lambda invocation helpers.
[core/config.py] — OMICS_REGISTER_WORKFLOW_LAMBDA setting.
[tests/api/test_workflow_deployments.py] — new tests covering both Lambda actions, missing env var, Lambda error response, missing ARN, caller-supplied external_id skip, and non-Omics missing-id rejection.

**Deploy notes**
Set OMICS_REGISTER_WORKFLOW_LAMBDA in the CloudFormation template.