### PR TITLE
Handle invalid "zero dates" in project listings gracefully

### DIFF
--- a/alembic/versions/a16a32f14864_repair_invalid_project_zero_dates.py
+++ b/alembic/versions/a16a32f14864_repair_invalid_project_zero_dates.py
@@ -1,0 +1,58 @@
+"""repair invalid project zero dates
+
+Revision ID: a16a32f14864
+Revises: 49e7d06e7eb4
+Create Date: 2026-07-01 09:55:24.089679
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a16a32f14864'
+down_revision: Union[str, Sequence[str], None] = '49e7d06e7eb4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Fallback timestamp matches the convention used by the original backfill
+# migration (49e7d06e7eb4) for rows whose date could not be determined.
+FALLBACK = '1970-01-01 00:00:00'
+
+
+def upgrade() -> None:
+    """
+    Repair invalid "zero dates" left behind by the backfill in 49e7d06e7eb4.
+
+    A project_id such as 'P-10000001-####' parsed via STR_TO_DATE produced
+    '1000-00-01' (month/day 0), which MySQL stored instead of returning NULL.
+    Those values crash datetime validation when reading projects, so reset
+    them to the same fallback used elsewhere for unknown dates.
+    """
+    bind = op.get_bind()
+    if bind.dialect.name != "mysql":
+        # Migration set is MySQL-targeted; nothing to repair on other engines.
+        return
+
+    for column in ("created_at", "last_modified"):
+        bind.execute(sa.text(f"""
+            UPDATE project
+            SET {column} = :fallback
+            WHERE {column} IS NULL
+               OR YEAR({column}) < 1970
+               OR MONTH({column}) = 0
+               OR DAY({column}) = 0
+        """), {"fallback": FALLBACK})
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Data repair is not reversible; the original invalid values are not
+    recoverable, so this is intentionally a no-op.
+    """
+    pass

--- a/api/project/models.py
+++ b/api/project/models.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import uuid
 from sqlmodel import SQLModel, Field, Relationship, UniqueConstraint
 from typing import List
-from pydantic import ConfigDict
+from pydantic import ConfigDict, field_validator
 
 from api.runs.models import SequencingRunPublic
 from api.samples.models import Sample
@@ -67,12 +67,30 @@ class ProjectPublic(SQLModel):
     project_id: str
     name: str | None
     created_by: str
-    created_at: datetime
-    last_modified: datetime
+    created_at: datetime | None
+    last_modified: datetime | None
     data_folder_uri: str | None
     results_folder_uri: str | None
     attributes: List[Attribute] | None
     sequencing_runs: List[SequencingRunPublic] | None = None
+
+    @field_validator("created_at", "last_modified", mode="before")
+    @classmethod
+    def _nullify_invalid_datetime(cls, value):
+        """
+        Map unparseable dates to None.
+
+        MySQL can store invalid "zero dates" (e.g. '1000-00-01 00:00:00',
+        month value 0) that the driver hands back as a raw string. These
+        cannot be parsed into a datetime, so surface them as None instead
+        of raising a ValidationError that would fail the whole request.
+        """
+        if isinstance(value, str):
+            try:
+                datetime.fromisoformat(value)
+            except ValueError:
+                return None
+        return value
 
 
 class ProjectsPublic(SQLModel):

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -168,20 +168,24 @@ def get_projects(
     results_bucket = get_setting_value(session, "RESULTS_BUCKET_URI")
 
     # Map to public project
-    public_projects = [
-        ProjectPublic(
-            project_id=project.project_id,
-            name=project.name,
-            created_at=project.created_at,
-            created_by=project.created_by,
-            last_modified=project.last_modified,
-            data_folder_uri=f"{data_bucket}/{project.project_id}/",
-            results_folder_uri=f"{results_bucket}/{project.project_id}/",
-            attributes=project.attributes,
-            sequencing_runs=None  # Sequencing runs are not included for performance reasons
-        )
-        for project in projects
-    ]
+    public_projects = []
+    for project in projects:
+        try:
+            public_projects.append(
+                ProjectPublic(
+                    project_id=project.project_id,
+                    name=project.name,
+                    created_at=project.created_at,
+                    created_by=project.created_by,
+                    last_modified=project.last_modified,
+                    data_folder_uri=f"{data_bucket}/{project.project_id}/",
+                    results_folder_uri=f"{results_bucket}/{project.project_id}/",
+                    attributes=project.attributes,
+                    sequencing_runs=None  # Sequencing runs are not included for performance reasons
+                )
+            )
+        except ValidationError as e:
+            logger.error("Skipping project %s due to invalid data: %s", project.project_id, e)
 
     return ProjectsPublic(
         data=public_projects,

--- a/api/project/services.py
+++ b/api/project/services.py
@@ -5,9 +5,11 @@ Services for the Project API
 from datetime import datetime, timezone as tz
 from typing import Literal
 import boto3
+import logging
+
 from fastapi import HTTPException, status
 from api.utils import check_duplicate_attribute_keys
-from pydantic import PositiveInt
+from pydantic import PositiveInt, ValidationError
 from pytz import timezone
 from sqlmodel import Session, func, select
 from sqlalchemy.orm import selectinload
@@ -46,6 +48,8 @@ from api.samples.models import (
     Attribute,
 )
 from api.runs.models import SequencingRun, SequencingRunPublic, SampleSequencingRun
+
+logger = logging.getLogger(__name__)
 
 
 def generate_project_id(*, session: Session) -> str:

--- a/core/db.py
+++ b/core/db.py
@@ -3,6 +3,7 @@ Database configuration
 """
 
 from sqlmodel import create_engine, Session
+from sqlalchemy import event
 from core.config import get_settings
 
 # Get database URI
@@ -22,6 +23,23 @@ else:
         pool_size=5,             # Number of connections in pool
         max_overflow=10          # Max additional connections during spikes
     )
+
+
+# For MySQL/MariaDB, enforce strict date handling on every new connection so
+# invalid "zero dates" (e.g. '1000-00-01') can no longer be written. Existing
+# bad rows are still returned on read and handled by ProjectPublic's validator;
+# this prevents new ones from being introduced.
+if database_uri.startswith("mysql"):
+    @event.listens_for(engine, "connect")
+    def _set_mysql_sql_mode(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute(
+                "SET SESSION sql_mode=CONCAT(@@sql_mode, "
+                "',NO_ZERO_DATE,NO_ZERO_IN_DATE,STRICT_TRANS_TABLES')"
+            )
+        finally:
+            cursor.close()
 
 
 # Yield session

--- a/tests/api/test_project_models.py
+++ b/tests/api/test_project_models.py
@@ -1,0 +1,66 @@
+"""
+Unit tests for Project API models.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from api.project.models import ProjectPublic
+
+
+def _make_project(**overrides):
+    """Build a ProjectPublic with sensible defaults, overriding as needed."""
+    data = dict(
+        project_id="P-20260101-0001",
+        name="Test Project",
+        created_by="testuser",
+        created_at="2026-01-01 00:00:00",
+        last_modified="2026-01-01 00:00:00",
+        data_folder_uri=None,
+        results_folder_uri=None,
+        attributes=None,
+    )
+    data.update(overrides)
+    return ProjectPublic(**data)
+
+
+def test_valid_datetime_strings_are_parsed():
+    """Valid date strings are parsed into datetime instances."""
+    project = _make_project(
+        created_at="2026-01-01 12:30:00",
+        last_modified="2026-06-15 08:00:00",
+    )
+    assert project.created_at == datetime(2026, 1, 1, 12, 30, 0)
+    assert project.last_modified == datetime(2026, 6, 15, 8, 0, 0)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        "1000-00-01 00:00:00",  # month 0 (the reported production value)
+        "0000-00-00 00:00:00",  # classic MySQL zero date
+        "2026-13-01 00:00:00",  # month out of range
+        "not-a-date",           # entirely unparseable
+    ],
+)
+def test_invalid_datetime_strings_become_none(bad_value):
+    """Unparseable/zero dates are coerced to None instead of raising."""
+    project = _make_project(created_at=bad_value, last_modified=bad_value)
+    assert project.created_at is None
+    assert project.last_modified is None
+
+
+def test_none_datetime_is_allowed():
+    """Explicit None passes through unchanged."""
+    project = _make_project(created_at=None, last_modified=None)
+    assert project.created_at is None
+    assert project.last_modified is None
+
+
+def test_actual_datetime_objects_pass_through():
+    """A real datetime object is accepted as-is."""
+    now = datetime(2026, 7, 1, 11, 27, 33)
+    project = _make_project(created_at=now, last_modified=now)
+    assert project.created_at == now
+    assert project.last_modified == now


### PR DESCRIPTION
## Handle invalid "zero dates" in project listings gracefully

### Problem

`GET /api/v1/projects` was returning **500 Internal Server Error** in staging:

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for ProjectPublic
created_at
  Input should be a valid datetime or date, month value is outside expected
  range of 1-12 [input_value='1000-00-01 00:00:00', input_type=str]
last_modified
  ... input_value='1000-00-01 00:00:00'
```

**Root cause:** one or more `project` rows contain invalid MySQL "zero dates" (`'1000-00-01 00:00:00'`, month `00`). Because `Project` is a `table=True` SQLModel, SQLAlchemy loads it without Pydantic validation, and the MySQL driver hands the unparseable value back as a raw string. It flows through untouched until `get_projects` builds `ProjectPublic` (a validating model), which rejects month `00`. Since the whole page of projects is built in one comprehension, a **single bad row failed the entire request** — making the project list unavailable.

These rows originate from the backfill in migration `49e7d06e7eb4`, which derives dates from `project_id` (`P-YYYYMMDD-####`) via `STR_TO_DATE`. A `project_id` like `P-10000001-####` yields `STR_TO_DATE('10000001','%Y%m%d')` → `'1000-00-01'`, which MySQL stored (with a warning, not `NULL`), so the migration's `IS NOT NULL` guard did not catch it.

### Changes

1. **`ProjectPublic` tolerates unparseable dates** (`api/project/models.py`)
   - `created_at` / `last_modified` are now `datetime | None`.
   - Added a `mode="before"` validator that returns `None` for any date string that can't be parsed by `datetime.fromisoformat`, instead of raising. Valid timestamps pass through unchanged.

2. **`get_projects` skips-and-logs bad rows** (`api/project/services.py`)
   - Building `ProjectPublic` is now per-row in a try/except; a row that still fails validation is logged with its `project_id` and skipped rather than 500-ing the whole endpoint.

3. **Prevent new bad dates at the source** (`core/db.py`)
   - For MySQL connections, a `connect` event listener appends `NO_ZERO_DATE,NO_ZERO_IN_DATE,STRICT_TRANS_TABLES` to `sql_mode` on every pooled connection (via `CONCAT(@@sql_mode, ...)` so existing modes are preserved). Scoped to MySQL only — SQLite/Postgres are unaffected.

4. **Repair existing bad rows** (`alembic/versions/a16a32f14864_repair_invalid_project_zero_dates.py`)
   - New migration resets `created_at` / `last_modified` to the `'1970-01-01'` fallback (same convention as the original backfill) for rows that are `NULL`, pre-1970, or have month/day `0`. MySQL-only; `downgrade()` is a no-op since the original invalid values are unrecoverable.

### Notes / follow-ups

- `sql_mode` enforcement only blocks **future** invalid writes; it does not clean existing rows — that is what the repair migration (change 4) handles.
- **Source bug not fully closed:** the `STR_TO_DATE` backfill in `49e7d06e7eb4` still exists and could regenerate zero-dates if re-run against an old data restore. The `sql_mode` change only affects the app's connections, not Alembic's. A complete fix would harden that backfill to validate the `STR_TO_DATE` result before writing. Out of scope for this PR — suggest a follow-up issue.

### Testing

- New unit tests (`tests/api/test_project_models.py`) verify `ProjectPublic` coerces unparseable/zero dates (`'1000-00-01'`, `'0000-00-00'`, `'2026-13-01'`, `'not-a-date'`) to `None`, accepts explicit `None`, and passes valid strings/`datetime` objects through unchanged — **7 passed**.
- Migration and modified modules syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
